### PR TITLE
ci-yml formatting and linting should pass for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - "**"
 
 env:
-  PYTHON_VERSION: "3.14"
+  PYTHON_VERSION: "3.12"
 
 jobs:
   types:


### PR DESCRIPTION
ci formatting and lintign should be compatible with python 3.12 onwards and not strictly python 3.14