### PR TITLE
Feat/clustering models

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ similarity_score = encoder.similarity_score(image1, image2)
 
 print(f"Similarity Score: {similarity_score}")
 ```
+
+A fitted encoder can be saved to a `.encoder` file and restored later:
+
+```python
+path = encoder.save_to_disk("vlad_oxford102")  # writes vlad_oxford102.encoder
+encoder = VLADEncoder.load_from_disk(path)
+```
 You can also visit the [introduction notebook](examples/getting_started.ipynb) for more examples.
 
 I also provided various notebooks for different use-cases. Feel free to check them out, and let me know if you
@@ -109,6 +116,11 @@ For more details on the dataset, please refer to the [documentation](pyvisim/dat
 
 ## Pretrained Models
 
+> [!CAUTION]
+> **Deprecated:** Loading pretrained models via the `KMeansWeights`/`GMMWeights` enums is deprecated
+> and will be removed in a future release. Train an encoder with `learn()` and persist it with `save_to_disk()`/
+> `load_from_disk()` (`.encoder` files) instead.
+
 The following pretrained models are provided for clustering and dimensionality reduction. All clustering
 models were trained with `k=256`. The choice of `k` was made arbitrarily
 based on the paper <sup>[5](#references)</sup>, where the authors tested with `k=32`, `64`, `128`, `256`, `512`, and so on.
@@ -116,7 +128,7 @@ Since higher values would take too long, I chose `k=256` as a balance between pe
 
 ### KMeans Models
 
-You can access these weights by importing `KMWeights` from the `pyvisim.encoders` module.
+You can access these weights by importing `KMeansWeights` from the `pyvisim.encoders` module.
 
 | Model Name                             | Features Extracted From | PCA Applied | Feature Dimensions |
 |----------------------------------------|-------------------------|-------------|--------------------|

--- a/pyvisim/__init__.py
+++ b/pyvisim/__init__.py
@@ -2,4 +2,4 @@
 PyVisim: A Python library for image similarity analysis using Image Encoders and Neural Networks.
 """
 
-__all__ = ["datasets", "encoders", "features", "eval"]
+__all__ = ["clustering", "datasets", "encoders", "features", "eval"]

--- a/pyvisim/clustering/__init__.py
+++ b/pyvisim/clustering/__init__.py
@@ -1,0 +1,11 @@
+from ._base_clustering import ClusteringModelBase
+from .gmm import GaussianMixtureModel
+from .kmeans import KMeans
+from .pca import PCA
+
+__all__ = [
+    "ClusteringModelBase",
+    "KMeans",
+    "GaussianMixtureModel",
+    "PCA",
+]

--- a/pyvisim/clustering/_base_clustering.py
+++ b/pyvisim/clustering/_base_clustering.py
@@ -1,0 +1,108 @@
+"""
+Base classes for the scikit-learn-backed models used by the image encoders.
+"""
+
+import abc
+from typing import Any, ClassVar, TypeVar
+
+import numpy as np
+from sklearn.exceptions import NotFittedError
+from sklearn.utils.validation import check_is_fitted
+
+_SklearnModelT = TypeVar("_SklearnModelT", bound="_SklearnModelBase")
+
+
+class _SklearnModelBase(abc.ABC):
+    """
+    Base class for models backed by a scikit-learn estimator.
+
+    :param model: Underlying scikit-learn estimator instance.
+    """
+
+    _sklearn_class: ClassVar[type[Any]]
+
+    def __init__(self, model: Any) -> None:
+        self._model = model
+
+    @property
+    def is_fitted(self) -> bool:
+        """Whether the underlying estimator has been fitted."""
+        try:
+            check_is_fitted(self._model)
+        except NotFittedError:
+            return False
+        return True
+
+    def _check_is_fitted(self) -> None:
+        """
+        Ensures the underlying estimator is fitted before accessing
+        fitted-only attributes.
+
+        :raises NotFittedError: If the underlying estimator is not fitted.
+        """
+        if not self.is_fitted:
+            raise NotFittedError(
+                f"This {type(self).__name__} instance is not fitted yet. "
+                "Call 'fit' with appropriate data before using this attribute."
+            )
+
+    @property
+    def n_features_in(self) -> int:
+        """
+        Number of features the fitted estimator expects as input.
+
+        :raises NotFittedError: If the underlying estimator is not fitted.
+        """
+        self._check_is_fitted()
+        return int(self._model.n_features_in_)
+
+    def fit(self, features: np.ndarray) -> None:
+        """
+        Fits the underlying estimator on the given feature matrix.
+
+        :param features: Feature matrix of shape (n_samples, n_features).
+        """
+        self._model.fit(features)
+
+    def _validate_sklearn_model(self) -> None:  # noqa: B027
+        """
+        Hook for subclasses to validate (or coerce) an estimator that was
+        passed in directly via :meth:`_from_sklearn`.
+        """
+
+    @classmethod
+    def _from_sklearn(cls: type[_SklearnModelT], model: Any) -> _SklearnModelT:
+        """
+        Creates a model from an existing scikit-learn estimator.
+
+        This is an internal constructor used to adopt pretrained estimators
+        (loaded from legacy weight files).
+
+        :param model: Estimator instance of the underlying scikit-learn class.
+        :return: A model backed by the given estimator.
+        :raises TypeError: If ``model`` is not an instance of the underlying class.
+        """
+        if not isinstance(model, cls._sklearn_class):
+            raise TypeError(
+                f"{cls.__name__} can only be created from instances of "
+                f"{cls._sklearn_class.__name__}, not {type(model).__name__}."
+            )
+        instance = cls.__new__(cls)
+        _SklearnModelBase.__init__(instance, model)
+        instance._validate_sklearn_model()
+        return instance
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(model={self._model!r})"
+
+
+class ClusteringModelBase(_SklearnModelBase):
+    """
+    Base class for clustering models.
+    """
+
+    @property
+    @abc.abstractmethod
+    def n_clusters(self) -> int:
+        """Number of clusters (or mixture components) of the estimator."""
+        raise NotImplementedError

--- a/pyvisim/clustering/gmm.py
+++ b/pyvisim/clustering/gmm.py
@@ -1,6 +1,5 @@
 """Gaussian Mixture Model used by the Fisher Vector encoder."""
 
-import warnings
 from typing import Any
 
 import numpy as np
@@ -40,12 +39,10 @@ class GaussianMixtureModel(ClusteringModelBase):
 
     def _validate_sklearn_model(self) -> None:
         if self._model.covariance_type != "diag":
-            warnings.warn(
-                "Attribute 'covariance_type' of the underlying GaussianMixture is "
-                "set to 'diag' because training will take too long otherwise.",
-                stacklevel=2,
+            raise ValueError(
+                f"{type(self).__name__} only supports covariance_type='diag', "
+                f"got {self._model.covariance_type!r}."
             )
-            self._model.covariance_type = "diag"
 
     @property
     def n_clusters(self) -> int:

--- a/pyvisim/clustering/gmm.py
+++ b/pyvisim/clustering/gmm.py
@@ -1,0 +1,94 @@
+"""Gaussian Mixture Model used by the Fisher Vector encoder."""
+
+import warnings
+from typing import Any
+
+import numpy as np
+from sklearn.mixture import GaussianMixture
+
+from ._base_clustering import ClusteringModelBase
+
+
+class GaussianMixtureModel(ClusteringModelBase):
+    """
+    Gaussian Mixture clustering model, used by the Fisher Vector encoder.
+    It is backed by :class:`sklearn.mixture.GaussianMixture`.
+
+    Only diagonal covariance matrices are supported: the Fisher Vector
+    computation relies on them, and training is much faster.
+
+    :param n_components: Number of mixture components.
+    :param gmm_params: Additional keyword arguments forwarded verbatim to
+        :class:`sklearn.mixture.GaussianMixture` (e.g. ``random_state``).
+    :raises ValueError: If a ``covariance_type`` other than ``"diag"`` is requested.
+    """
+
+    _sklearn_class = GaussianMixture
+
+    def __init__(self, n_components: int = 256, **gmm_params: Any) -> None:
+        covariance_type = gmm_params.pop("covariance_type", "diag")
+        if covariance_type != "diag":
+            raise ValueError(
+                f"{type(self).__name__} only supports covariance_type='diag', "
+                f"got {covariance_type!r}."
+            )
+        super().__init__(
+            GaussianMixture(
+                n_components=n_components, covariance_type="diag", **gmm_params
+            )
+        )
+
+    def _validate_sklearn_model(self) -> None:
+        if self._model.covariance_type != "diag":
+            warnings.warn(
+                "Attribute 'covariance_type' of the underlying GaussianMixture is "
+                "set to 'diag' because training will take too long otherwise.",
+                stacklevel=2,
+            )
+            self._model.covariance_type = "diag"
+
+    @property
+    def n_clusters(self) -> int:
+        """Number of mixture components of the GMM."""
+        return int(self._model.n_components)
+
+    @property
+    def weights(self) -> np.ndarray:
+        """
+        Mixture weights of each component, shape (n_components,).
+
+        :raises NotFittedError: If the underlying estimator is not fitted.
+        """
+        self._check_is_fitted()
+        return np.asarray(self._model.weights_)
+
+    @property
+    def means(self) -> np.ndarray:
+        """
+        Mean of each mixture component, shape (n_components, n_features).
+
+        :raises NotFittedError: If the underlying estimator is not fitted.
+        """
+        self._check_is_fitted()
+        return np.asarray(self._model.means_)
+
+    @property
+    def covariances(self) -> np.ndarray:
+        """
+        Diagonal covariance of each component, shape (n_components, n_features).
+
+        :raises NotFittedError: If the underlying estimator is not fitted.
+        """
+        self._check_is_fitted()
+        return np.asarray(self._model.covariances_)
+
+    def predict_proba(self, features: np.ndarray) -> np.ndarray:
+        """
+        Evaluates the components' posterior probability for each feature vector.
+
+        :param features: Feature matrix of shape (n_samples, n_features).
+        :return: Posterior probabilities, shape (n_samples, n_components).
+        :raises NotFittedError: If the underlying estimator is not fitted.
+        """
+        self._check_is_fitted()
+        return np.asarray(self._model.predict_proba(features))

--- a/pyvisim/clustering/kmeans.py
+++ b/pyvisim/clustering/kmeans.py
@@ -1,0 +1,50 @@
+"""K-Means clustering class used by the VLAD encoder."""
+
+from typing import Any
+
+import numpy as np
+from sklearn.cluster import KMeans as _SklearnKMeans
+
+from ._base_clustering import ClusteringModelBase
+
+
+class KMeans(ClusteringModelBase):
+    """
+    K-Means clustering model, used by the VLAD encoder. It is
+    backed by :class:`sklearn.cluster.KMeans`.
+
+    :param n_clusters: Number of clusters to form.
+    :param kmeans_params: Additional keyword arguments forwarded verbatim to
+        :class:`sklearn.cluster.KMeans` (e.g. ``random_state``, ``n_init``).
+    """
+
+    _sklearn_class = _SklearnKMeans
+
+    def __init__(self, n_clusters: int = 256, **kmeans_params: Any) -> None:
+        super().__init__(_SklearnKMeans(n_clusters=n_clusters, **kmeans_params))
+
+    @property
+    def n_clusters(self) -> int:
+        """Number of clusters of the K-Means model."""
+        return int(self._model.n_clusters)
+
+    @property
+    def cluster_centers(self) -> np.ndarray:
+        """
+        Coordinates of the cluster centers, shape (n_clusters, n_features).
+
+        :raises NotFittedError: If the underlying estimator is not fitted.
+        """
+        self._check_is_fitted()
+        return np.asarray(self._model.cluster_centers_)
+
+    def predict(self, features: np.ndarray) -> np.ndarray:
+        """
+        Predicts the closest cluster for each feature vector.
+
+        :param features: Feature matrix of shape (n_samples, n_features).
+        :return: Cluster index of each sample, shape (n_samples,).
+        :raises NotFittedError: If the underlying estimator is not fitted.
+        """
+        self._check_is_fitted()
+        return np.asarray(self._model.predict(features))

--- a/pyvisim/clustering/pca.py
+++ b/pyvisim/clustering/pca.py
@@ -1,0 +1,46 @@
+"""Principal Component Analysis model used by the image encoders."""
+
+from typing import Any
+
+import numpy as np
+from sklearn.decomposition import PCA as _SklearnPCA
+
+from ._base_clustering import _SklearnModelBase
+
+
+class PCA(_SklearnModelBase):
+    """
+    Principal Component Analysis model, used by the image encoders to
+    reduce the dimensionality of local features. It is backed by
+    :class:`sklearn.decomposition.PCA`.
+
+    :param n_components: Number of components to keep.
+    :param pca_params: Additional keyword arguments forwarded verbatim to
+        :class:`sklearn.decomposition.PCA` (e.g. ``whiten``, ``random_state``).
+    """
+
+    _sklearn_class = _SklearnPCA
+
+    def __init__(self, n_components: int, **pca_params: Any) -> None:
+        super().__init__(_SklearnPCA(n_components=n_components, **pca_params))
+
+    @property
+    def n_components(self) -> int:
+        """
+        Number of components of the fitted PCA.
+
+        :raises NotFittedError: If the underlying estimator is not fitted.
+        """
+        self._check_is_fitted()
+        return int(self._model.n_components_)
+
+    def transform(self, features: np.ndarray) -> np.ndarray:
+        """
+        Projects the given features onto the principal components.
+
+        :param features: Feature matrix of shape (n_samples, n_features).
+        :return: Reduced features of shape (n_samples, n_components).
+        :raises NotFittedError: If the underlying estimator is not fitted.
+        """
+        self._check_is_fitted()
+        return np.asarray(self._model.transform(features))

--- a/pyvisim/encoders/README.md
+++ b/pyvisim/encoders/README.md
@@ -29,6 +29,40 @@ differ in the way they aggregate these descriptors and the underlying clustering
 After the feature extraction step, the local features are aggregated to their respective cluster centers. The final
 encoding matrix is then flattened and normalized to produce the final feature vector representation of the image.
 
+## Configuring Encoders
+
+The encoders build their clustering models internally: VLAD always uses K-Means and the Fisher Vector encoder always
+uses a Gaussian Mixture Model (both implemented in `pyvisim.clustering`).
+
+```python
+from pyvisim.encoders import VLADEncoder, FisherVectorEncoder
+
+vlad = VLADEncoder(
+    n_clusters=256,
+    kmeans_params={"random_state": 42},
+    pca_params={"n_components": 64},
+)
+fisher = FisherVectorEncoder(
+    n_components=256,
+    gmm_params={"random_state": 42},
+)
+```
+
+Calling `learn(images)` fits the configured PCA (if any) and the clustering model. A fitted encoder can be saved to
+disk and restored later:
+
+```python
+vlad.learn(images)
+path = vlad.save_to_disk("vlad")  # writes vlad.encoder
+vlad = VLADEncoder.load_from_disk(path)
+```
+
+The `.encoder` file stores the fitted clustering model, the PCA model and the normalization hyperparameters. The
+feature extractor and the similarity function are not serialized; provide them again when loading.
+
+Loading pretrained models via the `KMeansWeights`/`GMMWeights` enums is deprecated and will be removed in a future
+release.
+
 ## Similarity Metric Pipeline
 The _Pipeline_ class is designed to handle multiple encoders simultaneously to compute feature vectors. It takes
 a list of encoders (instances of the ImageEncoderBase class defined in the '_base_encoder.py' file) and a function

--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -1,4 +1,5 @@
 import abc
+import pathlib
 import warnings
 from collections.abc import Callable, Iterable, Iterator, MutableSequence
 from enum import Enum
@@ -7,6 +8,7 @@ from typing import Any, ClassVar, TypeVar, cast
 
 import joblib
 import numpy as np
+from sklearn.exceptions import NotFittedError
 
 from .._base_classes import FeatureExtractorBase, SimilarityMetric
 from .._config import PICKLE_MODEL_FILES_PATH, setup_logging
@@ -15,6 +17,21 @@ from ..clustering import PCA, ClusteringModelBase
 from ..features._features import RootSIFT
 
 setup_logging()
+
+_ENCODER_FILE_SUFFIX = ".encoder"
+_ENCODER_FILE_FORMAT_VERSION = 1
+_ENCODER_STATE_KEYS = frozenset(
+    {
+        "encoder_class",
+        "clustering_model",
+        "pca",
+        "power_norm_weight",
+        "norm_order",
+        "epsilon",
+        "flatten",
+        "raise_error_when_pca_incompatible",
+    }
+)
 
 
 # Helper Functions
@@ -103,6 +120,7 @@ def _make_fallback_func(
 
 
 MethodT = TypeVar("MethodT", bound=Callable[..., Any])
+_EncoderT = TypeVar("_EncoderT", bound="ImageEncoderBase")
 
 
 def _tupleize_first_arg(func: MethodT) -> MethodT:  # noqa: UP047
@@ -413,6 +431,87 @@ class ImageEncoderBase(SimilarityMetric):
             features = self._pca.transform(features)
             print("   - New dimension after PCA reduction:", self._pca.n_components)
         self._clustering_model.fit(features)
+
+    def save_to_disk(self, path: str | pathlib.Path) -> pathlib.Path:
+        """
+        Saves the learned state of this encoder to a ``.encoder`` file.
+
+        The file contains the fitted clustering model, the PCA model (if any)
+        and the normalization hyperparameters. The feature extractor and the
+        similarity function are not serialized; provide them again when
+        calling :meth:`load_from_disk`.
+
+        :param path: Target file path. The ``.encoder`` suffix is appended if missing.
+        :return: The path of the written file.
+        :raises NotFittedError: If the clustering model is missing or not fitted.
+        """
+        if self._clustering_model is None or not self._clustering_model.is_fitted:
+            raise NotFittedError(
+                "Cannot save an encoder whose clustering model is not fitted. "
+                "Call 'learn' first."
+            )
+        path = pathlib.Path(path)
+        if path.suffix != _ENCODER_FILE_SUFFIX:
+            path = path.with_name(path.name + _ENCODER_FILE_SUFFIX)
+        state = {
+            "format_version": _ENCODER_FILE_FORMAT_VERSION,
+            "encoder_class": type(self).__name__,
+            "clustering_model": self._clustering_model,
+            "pca": self._pca,
+            "power_norm_weight": self.power_norm_weight,
+            "norm_order": self.norm_order,
+            "epsilon": self.epsilon,
+            "flatten": self.flatten,
+            "raise_error_when_pca_incompatible": self.raise_error_when_pca_incompatible,
+        }
+        joblib.dump(state, path)
+        return path
+
+    @classmethod
+    def load_from_disk(
+        cls: type[_EncoderT],
+        path: str | pathlib.Path,
+        *,
+        feature_extractor: FeatureExtractorBase | None = None,
+        similarity_func: Callable[
+            [np.ndarray, np.ndarray], np.ndarray
+        ] = cosine_similarity,
+    ) -> _EncoderT:
+        """
+        Loads an encoder previously saved with :meth:`save_to_disk`.
+
+        :param path: Path to the ``.encoder`` file.
+        :param feature_extractor: Feature extractor to use with the loaded
+            encoder. Defaults to RootSIFT. Its output dimension has to match
+            the input dimension of the saved PCA or clustering model.
+        :param similarity_func: Similarity function to use with the loaded encoder.
+        :return: A ready-to-use encoder instance.
+        :raises ValueError: If the file is not a valid ``.encoder`` file or
+            was saved by a different encoder class.
+        """
+        state = joblib.load(path)
+        if not isinstance(state, dict) or not _ENCODER_STATE_KEYS.issubset(state):
+            raise ValueError(f"File {path} is not a valid .encoder file.")
+        if state["encoder_class"] != cls.__name__:
+            raise ValueError(
+                f"File {path} was saved by {state['encoder_class']}. "
+                f"Load it with {state['encoder_class']}.load_from_disk instead."
+            )
+        encoder = cls(
+            feature_extractor=feature_extractor,
+            similarity_func=similarity_func,
+            power_norm_weight=state["power_norm_weight"],
+            norm_order=state["norm_order"],
+            epsilon=state["epsilon"],
+            flatten=state["flatten"],
+            raise_error_when_pca_incompatible=state[
+                "raise_error_when_pca_incompatible"
+            ],
+        )
+        if state["pca"] is not None:
+            encoder.pca = state["pca"]
+        encoder.clustering_model = state["clustering_model"]
+        return encoder
 
     @_tupleize_first_arg
     # @lru_cache(maxsize=4)

--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -148,6 +148,15 @@ class _PretrainedModels(Enum):
 
 
 class KMeansWeights(_PretrainedModels):
+    """
+    Pretrained K-Means weights trained on the Oxford-102 flower dataset.
+
+    .. deprecated::
+        Loading pretrained models via this enum is deprecated and will be
+        removed in a future release. Use ``save_to_disk``/``load_from_disk``
+        with ``.encoder`` files instead.
+    """
+
     OXFORD102_K256_VGG16_PCA = (
         f"{PICKLE_MODEL_FILES_PATH}/k_means_k256_deep_features_vgg16_pca.pkl"
     )
@@ -173,6 +182,15 @@ class _PCA(_PretrainedModels):
 
 
 class GMMWeights(_PretrainedModels):
+    """
+    Pretrained GMM weights trained on the Oxford-102 flower dataset.
+
+    .. deprecated::
+        Loading pretrained models via this enum is deprecated and will be
+        removed in a future release. Use ``save_to_disk``/``load_from_disk``
+        with ``.encoder`` files instead.
+    """
+
     OXFORD102_K256_VGG16_PCA = (
         f"{PICKLE_MODEL_FILES_PATH}/gmm_k256_deep_features_vgg16_pca.pkl"
     )
@@ -274,8 +292,18 @@ class ImageEncoderBase(SimilarityMetric):
         Loads a pretrained scikit-learn estimator (and its matching PCA,
         if any) into the encoder's clustering model class.
 
+        .. deprecated::
+            Will be removed in a future release together with the weight enums.
+
         :param weights: Pretrained weight enum member to load.
         """
+        warnings.warn(
+            "Loading pretrained models via KMeansWeights/GMMWeights is "
+            "deprecated and will be removed in a future release. Use "
+            "save_to_disk()/load_from_disk() with .encoder files instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
         if "PCA" in weights.name:
             self.pca = PCA._from_sklearn(_CLUSTERING_TO_PCA_MAPPING[weights].load())
         self.clustering_model = self._clustering_model_cls._from_sklearn(weights.load())

--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -20,6 +20,13 @@ setup_logging()
 
 _ENCODER_FILE_SUFFIX = ".encoder"
 _ENCODER_FILE_FORMAT_VERSION = 1
+_ENCODER_FILE_FORMAT_VERSION_COMPATIBILITY: dict[tuple[int, int], bool] = {
+    # TODO: when the next _ENCODER_FILE_FORMAT_VERSION comes, check if
+    # it's forward / backward compatible, then add entries like:
+    # (1, 2): True,  # version 1 can read files from version 2
+    #
+    # However, (2, 1) might not be True!!
+}
 _ENCODER_STATE_KEYS = frozenset(
     {
         "encoder_class",
@@ -530,6 +537,8 @@ class ImageEncoderBase(SimilarityMetric):
         state = joblib.load(path)
         if not isinstance(state, dict) or not _ENCODER_STATE_KEYS.issubset(state):
             raise ValueError(f"File {path} is not a valid .encoder file.")
+        # TODO: in the future, verify format version by checking
+        # compatibility via _ENCODER_FILE_FORMAT_VERSION_COMPATIBILITY
         if state["encoder_class"] != cls.__name__:
             raise ValueError(
                 f"File {path} was saved by {state['encoder_class']}. "

--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -457,7 +457,12 @@ class ImageEncoderBase(SimilarityMetric):
         print("   - Feature Extractor used:", self.feature_extractor.__class__.__name__)
         print("   - Dimension of the feature space:", feat_dim := features.shape[1])
         if dim_reduction_factor:
-            self._pca = PCA(n_components=feat_dim // dim_reduction_factor)
+            if (n_components := feat_dim // dim_reduction_factor) <= 0:
+                raise ValueError(
+                    f"dim_reduction_factor {dim_reduction_factor} is too large for the feature dimension {feat_dim}. "
+                    f"Resulting PCA components would be {n_components}. Please choose a smaller dim_reduction_factor."
+                )
+            self._pca = PCA(n_components=n_components)
         if self._pca is not None:
             if not self._pca.is_fitted:
                 self._pca.fit(features)

--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -3,17 +3,16 @@ import warnings
 from collections.abc import Callable, Iterable, Iterator, MutableSequence
 from enum import Enum
 from functools import wraps
-from typing import Any, TypeVar, cast
+from typing import Any, ClassVar, TypeVar, cast
 
 import joblib
 import numpy as np
-from sklearn.cluster import KMeans
-from sklearn.decomposition import PCA
-from sklearn.mixture import GaussianMixture
 
 from .._base_classes import FeatureExtractorBase, SimilarityMetric
 from .._config import PICKLE_MODEL_FILES_PATH, setup_logging
 from .._utils import cosine_similarity, read_image_rgb
+from ..clustering import PCA, ClusteringModelBase
+from ..features._features import RootSIFT
 
 setup_logging()
 
@@ -193,24 +192,30 @@ class ImageEncoderBase(SimilarityMetric):
 
     The encoding can be used for indexing, retrieval, clustering or classification tasks.
     :param feature_extractor: Feature extractor instance (should implement __call__).
+        Defaults to RootSIFT.
+    :param clustering_model: Clustering model (see ``pyvisim.clustering``)
+    used for generating descriptors.
     :param weights: Pretrained model for clustering. If provided, the clustering model will be loaded from the file,
     and `clustering_model` and `pca` parameters will be ignored.
-    :param clustering_model: Clustering model used for generating descriptors.
     :param power_norm_weight: Exponent for power normalization
     :param norm_order: Norm order for normalization (default: 2).
     :param epsilon: Small constant to avoid division by zero.
     :param flatten: Whether to flatten the computed descriptor vector (default: True).
     :param similarity_func: A function that takes two batches of vectors and returns a similarity score
     matrix with size (batch_1_size, batch_2_size).
-    :param pca: PCA model for dimensionality reduction (optional).
+    :param pca: PCA model (see ``pyvisim.clustering``) for dimensionality reduction
+    (optional). Subclasses build it from the ``pca_params`` dictionary passed to
+    their constructors.
     :param raise_error_when_pca_incompatible: When set to True, if the new clustering model has a different input size
                                         than the PCA model's output size, an Error will be raised"""
 
+    _clustering_model_cls: ClassVar[type[ClusteringModelBase]]
+
     def __init__(
         self,
-        feature_extractor: FeatureExtractorBase,
+        feature_extractor: FeatureExtractorBase | None = None,
+        clustering_model: ClusteringModelBase | None = None,
         weights: KMeansWeights | GMMWeights | None = None,
-        clustering_model: KMeans | GaussianMixture | None = None,
         similarity_func: Callable[
             [np.ndarray, np.ndarray], np.ndarray
         ] = cosine_similarity,
@@ -223,28 +228,39 @@ class ImageEncoderBase(SimilarityMetric):
     ):
         # Set important attributes via setters to trigger error handling
         self._feature_extractor: FeatureExtractorBase
-        self._clustering_model: KMeans | GaussianMixture | None = None
+        self._clustering_model: ClusteringModelBase | None = None
         self._pca: PCA | None = None
         self._similarity_func: Callable[[np.ndarray, np.ndarray], np.ndarray]
-
-        self.similarity_func = similarity_func
-        self.feature_extractor = feature_extractor
-
-        if weights is not None:
-            if "PCA" in weights.name:
-                self.pca = _CLUSTERING_TO_PCA_MAPPING[weights].load()
-            self.clustering_model = weights.load()
-        else:
-            if pca is not None:
-                self.pca = pca
-            if clustering_model is not None:
-                self.clustering_model = clustering_model
 
         self.power_norm_weight = power_norm_weight
         self.norm_order = norm_order
         self.epsilon = epsilon
         self.flatten = flatten
         self.raise_error_when_pca_incompatible = raise_error_when_pca_incompatible
+
+        self.similarity_func = similarity_func
+        self.feature_extractor = (
+            feature_extractor if feature_extractor is not None else RootSIFT()
+        )
+
+        if weights is not None:
+            self._load_pretrained_weights(weights)
+        else:
+            if pca is not None:
+                self.pca = pca
+            if clustering_model is not None:
+                self.clustering_model = clustering_model
+
+    def _load_pretrained_weights(self, weights: KMeansWeights | GMMWeights) -> None:
+        """
+        Loads a pretrained scikit-learn estimator (and its matching PCA,
+        if any) into the encoder's clustering model class.
+
+        :param weights: Pretrained weight enum member to load.
+        """
+        if "PCA" in weights.name:
+            self.pca = PCA._from_sklearn(_CLUSTERING_TO_PCA_MAPPING[weights].load())
+        self.clustering_model = self._clustering_model_cls._from_sklearn(weights.load())
 
     @property
     def feature_extractor(self) -> FeatureExtractorBase:
@@ -256,21 +272,18 @@ class ImageEncoderBase(SimilarityMetric):
             raise TypeError(
                 f"feature_extractor must be an instance of FeatureExtractorBase, not {type(feature_extractor)}"
             )
-        if self._pca is not None:
-            if feature_extractor.output_dim != self._pca.n_features_in_:
+        if self._pca is not None and self._pca.is_fitted:
+            if feature_extractor.output_dim != self._pca.n_features_in:
                 raise RuntimeError(
                     f"Feature Extractor outputs shape {feature_extractor.output_dim}, "
-                    f"But PCA accepts input dim {self._pca.n_features_in_}"
+                    f"But PCA accepts input dim {self._pca.n_features_in}"
                 )
         else:
-            if self._clustering_model is not None:
-                if (
-                    feature_extractor.output_dim
-                    != self._clustering_model.n_features_in_
-                ):
+            if self._clustering_model is not None and self._clustering_model.is_fitted:
+                if feature_extractor.output_dim != self._clustering_model.n_features_in:
                     raise RuntimeError(
                         f"Feature Extractor outputs shape {feature_extractor.output_dim}, "
-                        f"But clustering model accepts input dim {self._clustering_model.n_features_in_}"
+                        f"But clustering model accepts input dim {self._clustering_model.n_features_in}"
                     )
         self._feature_extractor = feature_extractor
 
@@ -286,44 +299,50 @@ class ImageEncoderBase(SimilarityMetric):
         self._similarity_func = check_desired_output(func, dummy1, dummy2)
 
     @property
-    def clustering_model(self) -> KMeans | GaussianMixture | None:
+    def clustering_model(self) -> ClusteringModelBase | None:
         return self._clustering_model
 
     @clustering_model.setter
-    def clustering_model(self, clustering_model: KMeans | GaussianMixture) -> None:
+    def clustering_model(self, clustering_model: ClusteringModelBase) -> None:
         self._set_clustering_model(clustering_model)
 
-    def _set_clustering_model(self, clustering_model: KMeans | GaussianMixture) -> None:
+    def _set_clustering_model(self, clustering_model: ClusteringModelBase) -> None:
         """
         Validates the given clustering model against the current PCA or
         feature extractor and stores it.
 
+        Dimension checks only apply to fitted models; an unfitted model is
+        stored as-is and validated once it is fitted via :meth:`learn`.
+
         :param clustering_model: Clustering model to validate and store.
         """
-        if self._pca:
-            if self._pca.n_components != clustering_model.n_features_in_:
+        if not clustering_model.is_fitted:
+            self._clustering_model = clustering_model
+            return
+        if self._pca is not None and self._pca.is_fitted:
+            if self._pca.n_components != clustering_model.n_features_in:
                 if self.raise_error_when_pca_incompatible:
                     raise RuntimeError(
                         f"PCA is incompatible with the new clustering model. "
                         f"PCA input size: {self._pca.n_components}, "
-                        f"New clustering model input size: {clustering_model.n_features_in_}. "
+                        f"New clustering model input size: {clustering_model.n_features_in}. "
                         f"If you want the PCA to be reset to None instead, set raise_error_when_pca_incompatible=False."
                     )
                 warnings.warn(
                     f"PCA is incompatible with the new clustering model. "
                     f"PCA input size: {self._pca.n_components}, "
-                    f"New clustering model input size: {clustering_model.n_features_in_}. "
+                    f"New clustering model input size: {clustering_model.n_features_in}. "
                     "PCA will be reset to None to avoid errors."
                     "If you want to raise an Error instead when this happens, set raise_error_when_pca_incompatible=False.",
                     stacklevel=2,
                 )
                 self._pca = None
         else:
-            if self._feature_extractor.output_dim != clustering_model.n_features_in_:
+            if self._feature_extractor.output_dim != clustering_model.n_features_in:
                 raise RuntimeError(
                     "Feature extractor output size has to match the clustering model input size. "
                     f"Feature extractor has output size {self._feature_extractor.output_dim}, "
-                    f"while clustering model has input size {clustering_model.n_features_in_}"
+                    f"while clustering model has input size {clustering_model.n_features_in}"
                 )
         self._clustering_model = clustering_model
 
@@ -333,19 +352,26 @@ class ImageEncoderBase(SimilarityMetric):
 
     @pca.setter
     def pca(self, pca: PCA) -> None:
-        if pca.n_features_in_ != self._feature_extractor.output_dim:
+        if not isinstance(pca, PCA):
+            raise ValueError(
+                f"The PCA model must be an instance of pyvisim.clustering.PCA, not {type(pca)}"
+            )
+        if not pca.is_fitted:
+            self._pca = pca
+            return
+        if pca.n_features_in != self._feature_extractor.output_dim:
             raise ValueError(
                 "PCA input size has to match the feature extractor output size. "
-                f"PCA model has input size {pca.n_features_in_}, "
+                f"PCA model has input size {pca.n_features_in}, "
                 f"while feature extractor has output size {self._feature_extractor.output_dim}"
             )
 
-        if self._clustering_model is not None:
-            if pca.n_components != self._clustering_model.n_features_in_:
+        if self._clustering_model is not None and self._clustering_model.is_fitted:
+            if pca.n_components != self._clustering_model.n_features_in:
                 raise ValueError(
                     "PCA input size has to match the clustering model input size."
                     f"PCA model has input size {pca.n_components}, "
-                    f"while clustering model has input size {self._clustering_model.n_features_in_}"
+                    f"while clustering model has input size {self._clustering_model.n_features_in}"
                 )
 
         self._pca = pca
@@ -355,41 +381,38 @@ class ImageEncoderBase(SimilarityMetric):
         images: Iterable[np.ndarray],
         /,
         *,
-        n_clusters: int,
         dim_reduction_factor: int | None = None,
-        **kwargs: Any,
     ) -> None:
         """
         Learns the visual vocabulary from the given images.
 
+        The clustering model configured at initialization (with the
+        scikit-learn parameters passed to the encoder constructor) is fitted
+        on the extracted features. If a PCA model is configured, the features
+        are reduced with it first (fitting it beforehand if necessary).
+
         :param images: An iterable of images.
-        :param n_clusters: Number of clusters to use for the clustering model
-        :param dim_reduction_factor: If a value is provided, PCA will be used to reduce the dimensionality of the feature space
-        :param kwargs: Additional arguments for the clustering model
+        :param dim_reduction_factor: If a value is provided, a new PCA model will be used to reduce the dimensionality of the feature space
+        :raises RuntimeError: If the encoder has no clustering model configured.
         """
+        if self._clustering_model is None:
+            raise RuntimeError(
+                "This encoder has no clustering model to fit. "
+                "Configure one via the constructor parameters."
+            )
         features = np.vstack([self.feature_extractor(image) for image in images])
         print("[INFO] Learning the visual vocabulary with the following parameters:")
-        print("   - Number of clusters:", n_clusters)
+        print("   - Number of clusters:", self._clustering_model.n_clusters)
         print("   - Feature Extractor used:", self.feature_extractor.__class__.__name__)
         print("   - Dimension of the feature space:", feat_dim := features.shape[1])
         if dim_reduction_factor:
-            print(
-                "   - New dimension after PCA reduction:",
-                new_dim := feat_dim // dim_reduction_factor,
-            )
-            self._pca = PCA(n_components=new_dim)
-            self._pca.fit(features)
+            self._pca = PCA(n_components=feat_dim // dim_reduction_factor)
+        if self._pca is not None:
+            if not self._pca.is_fitted:
+                self._pca.fit(features)
             features = self._pca.transform(features)
-        if self.__class__.__name__ == "VLADEncoder":
-            clustering_model = KMeans(n_clusters=n_clusters, **kwargs)
-        elif self.__class__.__name__ == "FisherVectorEncoder":
-            clustering_model = GaussianMixture(
-                n_components=n_clusters, **kwargs, covariance_type="diag"
-            )
-        else:
-            raise ValueError("Unknown encoder class.")
-        clustering_model.fit(features)
-        self.clustering_model = clustering_model
+            print("   - New dimension after PCA reduction:", self._pca.n_components)
+        self._clustering_model.fit(features)
 
     @_tupleize_first_arg
     # @lru_cache(maxsize=4)
@@ -438,12 +461,9 @@ class ImageEncoderBase(SimilarityMetric):
         return np.asarray(result, dtype=np.float32)
 
     def __repr__(self) -> str:
-        n_clusters = None
-        if self._clustering_model:
-            if hasattr(self._clustering_model, "n_clusters"):
-                n_clusters = self._clustering_model.n_clusters
-            elif hasattr(self._clustering_model, "n_components"):
-                n_clusters = self._clustering_model.n_components
+        n_clusters = (
+            self._clustering_model.n_clusters if self._clustering_model else None
+        )
         return (
             self.__class__.__name__
             + f"(feature_extractor={self.feature_extractor.__class__.__name__}, \n"

--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -440,7 +440,12 @@ class ImageEncoderBase(SimilarityMetric):
         :param images: An iterable of images.
         :param dim_reduction_factor: If a value is provided, a new PCA model will be used to reduce the dimensionality of the feature space
         :raises RuntimeError: If the encoder has no clustering model configured.
+        :raises ValueError: If dim_reduction_factor is provided but is not a positive integer.
         """
+        if dim_reduction_factor is not None and (
+            dim_reduction_factor <= 0 or not isinstance(dim_reduction_factor, int)
+        ):
+            raise ValueError("dim_reduction_factor must be a positive integer.")
         if self._clustering_model is None:
             raise RuntimeError(
                 "This encoder has no clustering model to fit. "

--- a/pyvisim/encoders/fisher_vector.py
+++ b/pyvisim/encoders/fisher_vector.py
@@ -1,15 +1,13 @@
-import warnings
 from collections.abc import Callable, Iterable
+from typing import Any, cast
 
 import numpy as np
 import torch
-from sklearn.decomposition import PCA
-from sklearn.mixture import GaussianMixture
 
 from .._base_classes import FeatureExtractorBase
 from .._utils import cosine_similarity
+from ..clustering import PCA, ClusteringModelBase, GaussianMixtureModel
 from ..encoders._base_encoder import GMMWeights, ImageEncoderBase
-from ..features import RootSIFT
 
 
 class FisherVectorEncoder(ImageEncoderBase):
@@ -20,17 +18,28 @@ class FisherVectorEncoder(ImageEncoderBase):
     (weights, means, and covariances) with respect to the feature descriptors extracted
     from the images. The representation is optionally power-normalized and L2-normalized.
 
+    The Gaussian Mixture Model is configured from the parameters passed to
+    this constructor (``n_components`` plus the optional ``gmm_params``
+    dictionary) and fitted by calling :meth:`learn`. An optional PCA
+    model for dimensionality reduction is configured the same way via
+    ``pca_params``.
+
     The output when calling `encode` has shape (2 * num_clusters * feature_dim + num_clusters,).
 
     :param feature_extractor: Feature extractor instance. Default is RootSIFT
-    :param gmm_model: Gaussian Mixture Model instance from scikit-learn.
+    :param weights: Pretrained GMM weights to load (deprecated).
+    :param n_components: Number of Gaussian mixture components (visual words) to use.
+    :param gmm_params: Dictionary of additional keyword arguments forwarded
+        verbatim to :class:`sklearn.mixture.GaussianMixture` (e.g. ``{"random_state": 0}``).
+    :param pca_params: Dictionary of keyword arguments for the PCA model used
+        for dimensionality reduction (see ``pyvisim.clustering.PCA``); must
+        include ``n_components``. If omitted, no PCA is applied.
     :param power_norm_weight: Exponent for power normalization
     :param norm_order: Norm order for normalization (default: 2).
     :param epsilon: Small constant to avoid division by zero.
     :param flatten: Whether to flatten the computed encoding vector (default: True).
     :param similarity_func: A function that takes two batches of vectors and returns a similarity score
     matrix with size (batch_1_size, batch_2_size).
-    :param pca: PCA model from scikit-learn for dimensionality reduction (optional).
     :param raise_error_when_pca_incompatible: When set to True, if the new clustering model has a different input size
                                         than the PCA model's output size, the PCA model will be reset to None.
 
@@ -39,11 +48,15 @@ class FisherVectorEncoder(ImageEncoderBase):
     [1] Hervé Jégou, Florent Perronnin, Matthijs Douze, Jorge Sánchez, Patrick Pérez, and Cordelia Schmid, "Aggregating Local Image Descriptors into Compact Codes," IEEE.
     """
 
+    _clustering_model_cls = GaussianMixtureModel
+
     def __init__(
         self,
         feature_extractor: FeatureExtractorBase | None = None,
         weights: GMMWeights | None = None,
-        gmm_model: GaussianMixture = None,
+        n_components: int = 256,
+        gmm_params: dict[str, Any] | None = None,
+        pca_params: dict[str, Any] | None = None,
         power_norm_weight: float = 0.5,
         norm_order: int = 2,
         epsilon: float = 1e-9,
@@ -51,51 +64,46 @@ class FisherVectorEncoder(ImageEncoderBase):
         similarity_func: Callable[
             [np.ndarray, np.ndarray], np.ndarray
         ] = cosine_similarity,
-        pca: PCA = None,
         raise_error_when_pca_incompatible: bool = False,
     ):
-        if feature_extractor is None:
-            feature_extractor = RootSIFT()
-        if gmm_model is not None:
-            if not isinstance(gmm_model, GaussianMixture):
-                raise ValueError(
-                    f"The clustering model must be an instance of GaussianMixture, not {type(gmm_model)}"
-                )
-            gmm_model.covariance_type = "diag"  # Otherwise, training will take forever
         if weights is not None:
             if (weights_class := weights.__class__.__name__) != "GMMWeights":
                 raise ValueError(
                     f"You can only pass an instance of GMMWeights, not {weights_class}"
                 )
+        if gmm_params and "n_components" in gmm_params:
+            raise ValueError(
+                "Pass 'n_components' directly to FisherVectorEncoder instead of inside gmm_params."
+            )
+        clustering_model = (
+            GaussianMixtureModel(n_components=n_components, **(gmm_params or {}))
+            if weights is None
+            else None
+        )
+        pca = PCA(**pca_params) if weights is None and pca_params is not None else None
         super().__init__(
-            feature_extractor,
-            weights,
-            gmm_model,
-            similarity_func,
-            power_norm_weight,
-            norm_order,
-            epsilon,
-            flatten,
-            pca,
-            raise_error_when_pca_incompatible,
+            feature_extractor=feature_extractor,
+            clustering_model=clustering_model,
+            weights=weights,
+            similarity_func=similarity_func,
+            power_norm_weight=power_norm_weight,
+            norm_order=norm_order,
+            epsilon=epsilon,
+            flatten=flatten,
+            pca=pca,
+            raise_error_when_pca_incompatible=raise_error_when_pca_incompatible,
         )
 
     @property
-    def clustering_model(self) -> GaussianMixture:
-        return self._clustering_model
+    def clustering_model(self) -> GaussianMixtureModel:
+        return cast(GaussianMixtureModel, self._clustering_model)
 
     @clustering_model.setter
-    def clustering_model(self, model: GaussianMixture) -> None:
-        if not isinstance(model, GaussianMixture):
+    def clustering_model(self, model: ClusteringModelBase) -> None:
+        if not isinstance(model, GaussianMixtureModel):
             raise ValueError(
-                f"The clustering model must be an instance of GaussianMixture, not {type(model)}"
+                f"The clustering model must be an instance of pyvisim.clustering.GaussianMixtureModel, not {type(model)}"
             )
-        if model.covariance_type != "diag":
-            warnings.warn(
-                "Attribute 'covariance_type' of the clustering model is set to 'diag' because training will take too long otherwise.",
-                stacklevel=2,
-            )
-            model.covariance_type = "diag"
         self._set_clustering_model(model)
 
     def encode(self, images: Iterable[np.ndarray] | np.ndarray) -> np.ndarray:
@@ -110,9 +118,9 @@ class FisherVectorEncoder(ImageEncoderBase):
                 descriptors = self.pca.transform(descriptors.astype(np.float32))
             num_descriptors = len(descriptors)
 
-            mixture_weights = self.clustering_model.weights_
-            means = self.clustering_model.means_
-            covariances = self.clustering_model.covariances_
+            mixture_weights = self.clustering_model.weights
+            means = self.clustering_model.means
+            covariances = self.clustering_model.covariances
 
             posterior_probabilities = self.clustering_model.predict_proba(descriptors)
 

--- a/pyvisim/encoders/vlad.py
+++ b/pyvisim/encoders/vlad.py
@@ -1,22 +1,27 @@
 from collections.abc import Callable, Iterable
+from typing import Any, cast
 
 import numpy as np
 import torch
-from sklearn.cluster import KMeans
-from sklearn.decomposition import PCA
 
 from .._base_classes import FeatureExtractorBase
 from .._utils import cosine_similarity
+from ..clustering import PCA, ClusteringModelBase, KMeans
 from ..encoders._base_encoder import ImageEncoderBase, KMeansWeights
-from ..features._features import RootSIFT
 
 
 class VLADEncoder(ImageEncoderBase):
     """
     This class encodes images into VLAD descriptor vectors
-    using a chosen feature extractor and a pretrained K-Means model,
+    using a chosen feature extractor and a K-Means clustering model,
     then compares two VLAD descriptor vectors with a user-specified
     or default (cosine) similarity function.
+
+    The K-Means model is configured from the parameters passed to this
+    constructor (``n_clusters`` plus the optional ``kmeans_params``
+    dictionary) and fitted by calling :meth:`learn`. An optional PCA
+    model for dimensionality reduction is configured the same way via
+    ``pca_params``.
 
     The output when calling `encode` has shape (num_clusters * feature_dim,).
 
@@ -24,14 +29,20 @@ class VLADEncoder(ImageEncoderBase):
 
     The encoding can be used for indexing, retrieval, clustering or classification tasks.
     :param feature_extractor: Feature extractor instance (should implement __call__).
-    :param kmeans_model: KMeans model instance from scikit-learn.
+        Defaults to RootSIFT.
+    :param weights: Pretrained K-Means weights to load (deprecated).
+    :param n_clusters: Number of K-Means clusters (visual words) to use.
+    :param kmeans_params: Dictionary of additional keyword arguments forwarded
+        verbatim to :class:`sklearn.cluster.KMeans` (e.g. ``{"random_state": 0}``).
+    :param pca_params: Dictionary of keyword arguments for the PCA model used
+        for dimensionality reduction (see ``pyvisim.clustering.PCA``); must
+        include ``n_components``. If omitted, no PCA is applied.
     :param power_norm_weight: Exponent for power normalization
     :param norm_order: Norm order for normalization (default: 2).
     :param epsilon: Small constant to avoid division by zero.
     :param flatten: Whether to flatten the computed descriptor vector (default: True).
     :param similarity_func: A function that takes two batches of vectors and returns a similarity score
     matrix with size (batch_1_size, batch_2_size).
-    :param pca: PCA model from scikit-learn for dimensionality reduction (optional).
     :param raise_error_when_pca_incompatible: When set to True, if the new clustering model has a different input size
                                         than the PCA model's output size, the PCA model will be reset to None.
 
@@ -42,11 +53,15 @@ class VLADEncoder(ImageEncoderBase):
     [3] Hervé Jégou, Florent Perronnin, Matthijs Douze, Jorge Sánchez, Patrick Pérez, and Cordelia Schmid, "Aggregating Local Image Descriptors into Compact Codes," IEEE.
     """
 
+    _clustering_model_cls = KMeans
+
     def __init__(
         self,
         feature_extractor: FeatureExtractorBase | None = None,
         weights: KMeansWeights | None = None,
-        kmeans_model: KMeans = None,
+        n_clusters: int = 256,
+        kmeans_params: dict[str, Any] | None = None,
+        pca_params: dict[str, Any] | None = None,
         power_norm_weight: float = 1,  # no paper found where power norm weight is used for VLAD
         norm_order: int = 2,
         epsilon: float = 1e-9,
@@ -54,43 +69,45 @@ class VLADEncoder(ImageEncoderBase):
         similarity_func: Callable[
             [np.ndarray, np.ndarray], np.ndarray
         ] = cosine_similarity,
-        pca: PCA = None,
         raise_error_when_pca_incompatible: bool = False,
     ) -> None:
-        if feature_extractor is None:
-            feature_extractor = RootSIFT()
-        if kmeans_model is not None:
-            if not isinstance(kmeans_model, KMeans):
-                raise ValueError(
-                    f"The clustering model must be an instance of KMeans, not {type(kmeans_model)}"
-                )
         if weights is not None:
             if (weights_class := weights.__class__.__name__) != "KMeansWeights":
                 raise ValueError(
                     f"You can only pass an instance of KMeansWeights, not {weights_class}"
                 )
+        if kmeans_params and "n_clusters" in kmeans_params:
+            raise ValueError(
+                "Pass 'n_clusters' directly to VLADEncoder instead of inside kmeans_params."
+            )
+        clustering_model = (
+            KMeans(n_clusters=n_clusters, **(kmeans_params or {}))
+            if weights is None
+            else None
+        )
+        pca = PCA(**pca_params) if weights is None and pca_params is not None else None
         super().__init__(
-            feature_extractor,
-            weights,
-            kmeans_model,
-            similarity_func,
-            power_norm_weight,
-            norm_order,
-            epsilon,
-            flatten,
-            pca,
-            raise_error_when_pca_incompatible,
+            feature_extractor=feature_extractor,
+            clustering_model=clustering_model,
+            weights=weights,
+            similarity_func=similarity_func,
+            power_norm_weight=power_norm_weight,
+            norm_order=norm_order,
+            epsilon=epsilon,
+            flatten=flatten,
+            pca=pca,
+            raise_error_when_pca_incompatible=raise_error_when_pca_incompatible,
         )
 
     @property
     def clustering_model(self) -> KMeans:
-        return self._clustering_model
+        return cast(KMeans, self._clustering_model)
 
     @clustering_model.setter
-    def clustering_model(self, model: KMeans) -> None:
+    def clustering_model(self, model: ClusteringModelBase) -> None:
         if not isinstance(model, KMeans):
             raise ValueError(
-                f"The clustering model must be an instance of KMeans, not {type(model)}"
+                f"The clustering model must be an instance of pyvisim.clustering.KMeans, not {type(model)}"
             )
         self._set_clustering_model(model)
 
@@ -111,7 +128,7 @@ class VLADEncoder(ImageEncoderBase):
                 )
 
             labels = self.clustering_model.predict(descriptors.astype(np.float32))
-            centroids = self.clustering_model.cluster_centers_
+            centroids = self.clustering_model.cluster_centers
 
             k = len(centroids)
             dim = descriptors.shape[1]


### PR DESCRIPTION
### Related Issues

- Currentl, sklearn objects are exposed to Public API. This is removed, and pyvisim's own clustering objects are used instead to avoid compatibility issues (currently, these are only sklearn wrappers)

### Proposed Changes

This PR introduces a `pyvisim.clustering` sub-package and refactors the encoder API around it. It contains one breaking change.

**New: `pyvisim/clustering/` module** (`feat(clustering)`)
- Added `KMeans`, `GaussianMixtureModel`, and `PCA` clustering models, each owning the underlying scikit-learn estimator and exposing typed getters for the attributes the encoders need (`cluster_centers`, `weights`, `means`, `covariances`, `n_components`, `n_features_in`, etc.).
- Models are created unfitted and accept scikit-learn constructor parameters directly, decoupling encoder configuration from raw sklearn objects.

**Breaking change: encoder params-at-init API** (`refactor(encoders)!`)
- `VLADEncoder` and `FisherVectorEncoder` no longer accept scikit-learn estimators (`kmeans_model`, `gmm_model`, `pca`) in their constructors.
- Encoders now build the matching `pyvisim.clustering` models themselves from `n_clusters`/`n_components` and optional `kmeans_params`/`gmm_params`/`pca_params` dicts forwarded verbatim to the underlying sklearn estimators.
- `learn()` no longer takes `n_clusters`/`kwargs`; it fits models configured at initialization. PCA is now applied (and fitted first if needed) before fitting the clustering model.
- Default `RootSIFT` feature extractor moved into `ImageEncoderBase`.
- Loading pre-trained `KMeansWeights`/`GMMWeights` still works; the loaded estimators are adopted by the corresponding pyvisim models.

**New: encoder persistence** (`feat(encoders)`)
- `save_to_disk()` / `load_from_disk()` serialize the fitted clustering model, PCA model, and normalization hyperparameters to a versioned `.encoder` file.
- Feature extractor and similarity function are provided again at load time; dimension validation runs on restore.
- Intended as the long-term replacement for `KMeansWeights`/`GMMWeights` loading.

**Deprecation: `KMeansWeights`/`GMMWeights` loading** (`feat(encoders)`)
- Passing weights enums to encoder constructors now emits a `DeprecationWarning`. The enums and the loading path will be removed in a future release.

**Docs** (`docs`)
- Updated top-level `README.md` and added `pyvisim/encoders/README.md` documenting the new params-at-init API, `kmeans_params`/`gmm_params`/`pca_params` dicts, and `save_to_disk`/`load_from_disk` with `.encoder` files.
- Marked `KMeansWeights`/`GMMWeights` as deprecated in docstrings and README.

### How did you test it?

- `make test-types` and `make fmt` pass on the branch.
- Encoder construction, `learn()`, `save_to_disk()`, and `load_from_disk()` exercised via the existing test suite and manually against the `getting_started` notebook.
- Deprecation warnings verified by passing weights enums to an encoder constructor.

### Notes for the reviewer

- The breaking change is limited to the encoder constructor signatures. Any caller that previously passed a fitted sklearn object must now pass the equivalent parameter dict and let the encoder build its own clustering model.
- `KMeansWeights`/`GMMWeights` loading is still functional but deprecated — callers should migrate to `save_to_disk`/`load_from_disk`.
- The `pyvisim/clustering/_base_clustering.py` abstract base holds the shared interface; reviewers may want to verify the getter contracts match what `_base_encoder.py` consumes.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] When applicable: I have reviewed the AI-generated code sections, according to [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#using-ai-to-contribute).
- [x] I have run [pre-commit hooks](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#set-up-developer-environment) and fixed any issue.
