### PR TITLE
feat: added public types ImageInput, MatLike, and now supports torch images.

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -12,6 +12,7 @@ pyvisim/
 ├── _config.py           Paths and logging setup
 ├── _utils.py            cosine_similarity, image IO, clustering + plotting helpers
 ├── _errors.py           Custom exceptions
+├── typing/              Public types and helper methods
 ├── eval.py              Retrieval metrics (top-k, mAP, accuracy)
 ├── encoders/            VLAD, Fisher Vector, Pipeline, pretrained weights
 ├── features/            SIFT, RootSIFT, DeepConvFeature, Lambda
@@ -21,6 +22,7 @@ pyvisim/
 
 Per-area docs:
 
+- [Typing](typing.md): Public types (`MatLike`, `ImageInput`).
 - [Encoders](encoders/): how images become vectors.
 - [Features](features/): how local descriptors are extracted from an image.
 - [Neural networks](neural_networks/): planned Siamese network.
@@ -60,8 +62,11 @@ Everything is built on the two abstract base classes in
 
 ## Design decisions worth knowing
 
-- **NumPy images only.** For the current implementation, only NumPy images are accepted.
-  It is still open whether to switch completely to PyTorch, or support both.
+- **NumPy, torch, or array-like images.** Encoders and feature extractors accept `MatLike`
+  inputs: NumPy arrays, PyTorch tensors, or anything `numpy.asarray` can turn into a
+  numeric array. Use the `dims` string (e.g. `"HWC"`, `"BCHW"`) to describe the axis
+  layout, and `value_range` to rescale float inputs into `[0, 255]`. See
+  [typing.md](typing.md).
 - **Similarity function is pluggable and guarded.** Any callable taking two `(N, D)`
   and `(M, D)` arrays and returning an `(N, M)` matrix can be used. On assignment it
   is probed with dummy input; if it does not return the expected shape,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ disallow_untyped_calls = true
 no_implicit_optional = true
 check_untyped_defs = true
 exclude = ["^build/", "^dist/", "^\\.venv/", "^venv/"]
+plugins = ["numpy.typing.mypy_plugin"]
 
 # Third-party libraries that ship without type stubs or a py.typed marker.
 [[tool.mypy.overrides]]

--- a/pyvisim/__init__.py
+++ b/pyvisim/__init__.py
@@ -1,5 +1,5 @@
 """
-PyVisim: A Python library for image similarity analysis using Image Encoders and Neural Networks.
+pyvisim: A Python library for image similarity analysis using Image Encoders and Neural Networks.
 """
 
-__all__ = ["clustering", "datasets", "encoders", "features", "eval"]
+__all__ = ["clustering", "datasets", "encoders", "features", "eval", "typing"]

--- a/pyvisim/_base_classes.py
+++ b/pyvisim/_base_classes.py
@@ -1,9 +1,7 @@
 import abc
 import logging
 
-import numpy as np
-
-from .typing import ImageInput, MatLike
+from .typing import Float32NumpyArray, FloatNumpyArray, ImageInput, MatLike
 
 
 class SimilarityMetric(abc.ABC):
@@ -23,7 +21,7 @@ class SimilarityMetric(abc.ABC):
         *,
         dims: str = "HWC",
         value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> np.ndarray:
+    ) -> FloatNumpyArray:
         """
         Compute a similarity score between two images.
 
@@ -62,7 +60,7 @@ class FeatureExtractorBase(abc.ABC):
         *,
         dims: str = "HWC",
         value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> np.ndarray:
+    ) -> Float32NumpyArray:
         """
         Extracts features from an image.
 

--- a/pyvisim/_base_classes.py
+++ b/pyvisim/_base_classes.py
@@ -1,8 +1,9 @@
 import abc
 import logging
-from collections.abc import Iterable
 
 import numpy as np
+
+from .typing import ImageInput, MatLike
 
 
 class SimilarityMetric(abc.ABC):
@@ -16,13 +17,28 @@ class SimilarityMetric(abc.ABC):
 
     @abc.abstractmethod
     def similarity_score(
-        self, image1: Iterable[np.ndarray], image2: Iterable[np.ndarray]
+        self,
+        image1: ImageInput,
+        image2: ImageInput,
+        *,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
     ) -> np.ndarray:
         """
         Compute a similarity score between two images.
 
-        :param image1: First image
-        :param image2: Second image
+        :param image1: First (batch of) image(s) as ``MatLike`` (NumPy array,
+            torch tensor or array-like).
+        :param image2: Second (batch of) image(s) as ``MatLike``.
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
+            (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
+            width × channels (NumPy/OpenCV single-image layout, **default**);
+            ``"CHW"`` is channels × height × width (PyTorch single-image layout);
+            ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
+            See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in;
+            converted into the canonical ``[0, 255]`` range.
         :return: A similarity score matrix
         """
         pass
@@ -39,11 +55,27 @@ class FeatureExtractorBase(abc.ABC):
     _logger = logging.getLogger("Feature_Extractor")
 
     @abc.abstractmethod
-    def __call__(self, image: np.ndarray, /) -> np.ndarray:
+    def __call__(
+        self,
+        image: MatLike,
+        /,
+        *,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
+    ) -> np.ndarray:
         """
         Extracts features from an image.
 
-        :param image: Input image (NumPy array).
+        :param image: Input image as ``MatLike`` (NumPy array, torch tensor or
+            array-like). It is normalized to a canonical ``uint8`` ``(H, W, C)``
+            image before extraction.
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels.
+            For example, ``"HWC"`` is height × width × channels (NumPy/OpenCV
+            layout, **default**); ``"CHW"`` is channels × height × width (PyTorch
+            layout). See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in;
+            converted into the canonical ``[0, 255]`` range.
         :return: Feature descriptors (NumPy array).
         """
         pass

--- a/pyvisim/_utils.py
+++ b/pyvisim/_utils.py
@@ -182,8 +182,8 @@ def plot_and_save_heatmap(
 
     figsize = (
         (
-            matrix.shape[1] * 0.7,
-            matrix.shape[0] * 0.7,
+            int(matrix.shape[1] * 0.7),
+            int(matrix.shape[0] * 0.7),
         )
         if figsize is None
         else figsize

--- a/pyvisim/_utils.py
+++ b/pyvisim/_utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import cv2
 import matplotlib.pyplot as plt
@@ -13,8 +13,16 @@ from sklearn.metrics import (
 )
 from sklearn.metrics.pairwise import cosine_similarity as cs
 
+from .typing import (
+    Float64NumpyArray,
+    FloatNumpyArray,
+    IntNumpyArray,
+    NumpyArray,
+    UInt8NumpyArray,
+)
 
-def read_image_rgb(path: str) -> np.ndarray:
+
+def read_image_rgb(path: str) -> UInt8NumpyArray:
     """
     Read an image from disk and convert it to RGB.
 
@@ -25,10 +33,10 @@ def read_image_rgb(path: str) -> np.ndarray:
     image = cv2.imread(path)
     if image is None:
         raise FileNotFoundError(f"Could not read image at '{path}'.")
-    return cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+    return cast(UInt8NumpyArray, cv2.cvtColor(image, cv2.COLOR_BGR2RGB))
 
 
-def cosine_similarity(x: np.ndarray, y: np.ndarray) -> np.ndarray:
+def cosine_similarity(x: FloatNumpyArray, y: FloatNumpyArray) -> Float64NumpyArray:
     """
     Compute the cosine similarity between two matrices.
 
@@ -51,7 +59,7 @@ def cosine_similarity(x: np.ndarray, y: np.ndarray) -> np.ndarray:
     return np.asarray(cs(x, y))
 
 
-def plot_image(image: np.ndarray | torch.Tensor, title: str = "Image") -> None:
+def plot_image(image: UInt8NumpyArray | torch.Tensor, title: str = "Image") -> None:
     """
     Plot a single image.
 
@@ -71,11 +79,11 @@ def plot_image(image: np.ndarray | torch.Tensor, title: str = "Image") -> None:
 
 
 def cluster_and_return_labels(
-    data: np.ndarray,
+    data: FloatNumpyArray,
     method: Literal["kmeans", "dbscan", "spectral"] = "kmeans",
     n_clusters: int | None = None,
     **kwargs: Any,
-) -> np.ndarray:
+) -> IntNumpyArray:
     """
     Clusters 'data' using the specified method.
 
@@ -111,8 +119,8 @@ def cluster_and_return_labels(
 
 
 def cluster_images_and_generate_statistics(
-    features: np.ndarray,
-    true_labels: np.ndarray,
+    features: FloatNumpyArray,
+    true_labels: IntNumpyArray,
     n_clusters: int,
     method: Literal["kmeans", "dbscan", "spectral"] = "kmeans",
     **kwargs: Any,
@@ -142,7 +150,7 @@ def cluster_images_and_generate_statistics(
 
 
 def plot_and_save_heatmap(
-    matrix: list[Any] | np.ndarray | torch.Tensor,
+    matrix: list[Any] | NumpyArray | torch.Tensor,
     figsize: tuple[int, int] | None = None,
     x_tick_labels: list[str] | None = None,
     y_tick_labels: list[str] | None = None,

--- a/pyvisim/clustering/_base_clustering.py
+++ b/pyvisim/clustering/_base_clustering.py
@@ -5,9 +5,10 @@ Base classes for the scikit-learn-backed models used by the image encoders.
 import abc
 from typing import Any, ClassVar, TypeVar
 
-import numpy as np
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.validation import check_is_fitted
+
+from ..typing import FloatNumpyArray
 
 _SklearnModelT = TypeVar("_SklearnModelT", bound="_SklearnModelBase")
 
@@ -56,7 +57,7 @@ class _SklearnModelBase(abc.ABC):
         self._check_is_fitted()
         return int(self._model.n_features_in_)
 
-    def fit(self, features: np.ndarray) -> None:
+    def fit(self, features: FloatNumpyArray) -> None:
         """
         Fits the underlying estimator on the given feature matrix.
 

--- a/pyvisim/clustering/gmm.py
+++ b/pyvisim/clustering/gmm.py
@@ -5,6 +5,7 @@ from typing import Any
 import numpy as np
 from sklearn.mixture import GaussianMixture
 
+from ..typing import Float64NumpyArray, FloatNumpyArray
 from ._base_clustering import ClusteringModelBase
 
 
@@ -50,7 +51,7 @@ class GaussianMixtureModel(ClusteringModelBase):
         return int(self._model.n_components)
 
     @property
-    def weights(self) -> np.ndarray:
+    def weights(self) -> Float64NumpyArray:
         """
         Mixture weights of each component, shape (n_components,).
 
@@ -60,7 +61,7 @@ class GaussianMixtureModel(ClusteringModelBase):
         return np.asarray(self._model.weights_)
 
     @property
-    def means(self) -> np.ndarray:
+    def means(self) -> Float64NumpyArray:
         """
         Mean of each mixture component, shape (n_components, n_features).
 
@@ -70,7 +71,7 @@ class GaussianMixtureModel(ClusteringModelBase):
         return np.asarray(self._model.means_)
 
     @property
-    def covariances(self) -> np.ndarray:
+    def covariances(self) -> Float64NumpyArray:
         """
         Diagonal covariance of each component, shape (n_components, n_features).
 
@@ -79,7 +80,7 @@ class GaussianMixtureModel(ClusteringModelBase):
         self._check_is_fitted()
         return np.asarray(self._model.covariances_)
 
-    def predict_proba(self, features: np.ndarray) -> np.ndarray:
+    def predict_proba(self, features: FloatNumpyArray) -> Float64NumpyArray:
         """
         Evaluates the components' posterior probability for each feature vector.
 

--- a/pyvisim/clustering/kmeans.py
+++ b/pyvisim/clustering/kmeans.py
@@ -5,6 +5,7 @@ from typing import Any
 import numpy as np
 from sklearn.cluster import KMeans as _SklearnKMeans
 
+from ..typing import FloatNumpyArray, IntNumpyArray
 from ._base_clustering import ClusteringModelBase
 
 
@@ -29,7 +30,7 @@ class KMeans(ClusteringModelBase):
         return int(self._model.n_clusters)
 
     @property
-    def cluster_centers(self) -> np.ndarray:
+    def cluster_centers(self) -> FloatNumpyArray:
         """
         Coordinates of the cluster centers, shape (n_clusters, n_features).
 
@@ -38,7 +39,7 @@ class KMeans(ClusteringModelBase):
         self._check_is_fitted()
         return np.asarray(self._model.cluster_centers_)
 
-    def predict(self, features: np.ndarray) -> np.ndarray:
+    def predict(self, features: FloatNumpyArray) -> IntNumpyArray:
         """
         Predicts the closest cluster for each feature vector.
 

--- a/pyvisim/clustering/pca.py
+++ b/pyvisim/clustering/pca.py
@@ -5,6 +5,7 @@ from typing import Any
 import numpy as np
 from sklearn.decomposition import PCA as _SklearnPCA
 
+from ..typing import Float64NumpyArray, FloatNumpyArray
 from ._base_clustering import _SklearnModelBase
 
 
@@ -34,7 +35,7 @@ class PCA(_SklearnModelBase):
         self._check_is_fitted()
         return int(self._model.n_components_)
 
-    def transform(self, features: np.ndarray) -> np.ndarray:
+    def transform(self, features: FloatNumpyArray) -> Float64NumpyArray:
         """
         Projects the given features onto the principal components.
 

--- a/pyvisim/datasets/datasets.py
+++ b/pyvisim/datasets/datasets.py
@@ -2,7 +2,6 @@ import logging
 import os
 from multiprocessing import Process
 
-import numpy as np
 import requests
 import scipy
 from platformdirs import user_cache_dir
@@ -12,6 +11,7 @@ from tqdm import tqdm
 
 from pyvisim._config import setup_logging
 from pyvisim._utils import read_image_rgb
+from pyvisim.typing import UInt8NumpyArray
 
 setup_logging()
 
@@ -207,7 +207,7 @@ def download_oxford_flowers_data() -> None:
     logger.info("Oxford Flowers dataset downloaded and processed successfully.")
 
 
-class OxfordFlowerDataset(Dataset[tuple[np.ndarray, int, str]]):
+class OxfordFlowerDataset(Dataset[tuple[UInt8NumpyArray, int, str]]):
     """
     Oxford Flower Dataset. It can be found at: https://www.robots.ox.ac.uk/~vgg/data/flowers/102/index.html.
 
@@ -309,7 +309,7 @@ class OxfordFlowerDataset(Dataset[tuple[np.ndarray, int, str]]):
         """
         return len(self.image_paths)
 
-    def __getitem__(self, idx: int) -> tuple[np.ndarray, int, str]:
+    def __getitem__(self, idx: int) -> tuple[UInt8NumpyArray, int, str]:
         """
         Get an image and its corresponding label.
 

--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -15,7 +15,12 @@ from .._config import PICKLE_MODEL_FILES_PATH, setup_logging
 from .._utils import cosine_similarity, read_image_rgb
 from ..clustering import PCA, ClusteringModelBase
 from ..features._features import RootSIFT
-from ..typing import ImageInput
+from ..typing import (
+    Float32NumpyArray,
+    FloatNumpyArray,
+    ImageInput,
+    SimilarityFunc,
+)
 from .utils import iter_images
 
 setup_logging()
@@ -45,10 +50,10 @@ _ENCODER_STATE_KEYS = frozenset(
 
 # Helper Functions
 def check_desired_output(
-    similarity_func: Callable[[np.ndarray, np.ndarray], Any],
-    vecs1: np.ndarray,
-    vecs2: np.ndarray,
-) -> Callable[[np.ndarray, np.ndarray], np.ndarray]:
+    similarity_func: Callable[[FloatNumpyArray, FloatNumpyArray], Any],
+    vecs1: FloatNumpyArray,
+    vecs2: FloatNumpyArray,
+) -> SimilarityFunc:
     """
     Checks the output of the given similarity_func(vecs1, vecs2).
     Requirements:
@@ -103,14 +108,14 @@ def check_desired_output(
 
 
 def _make_fallback_func(
-    sim_func: Callable[[np.ndarray, np.ndarray], Any],
-) -> Callable[[np.ndarray, np.ndarray], np.ndarray]:
+    sim_func: Callable[[FloatNumpyArray, FloatNumpyArray], Any],
+) -> SimilarityFunc:
     """
     Returns a new function that loops row-by-row if the original
     similarity function can't handle batch mode.
     """
 
-    def fallback(vecs1: np.ndarray, vecs2: np.ndarray) -> np.ndarray:
+    def fallback(vecs1: FloatNumpyArray, vecs2: FloatNumpyArray) -> Float32NumpyArray:
         N = vecs1.shape[0]  # (N, D)
         M = vecs2.shape[0]  # (M, D)
         out = np.zeros((N, M), dtype=np.float32)
@@ -261,9 +266,7 @@ class ImageEncoderBase(SimilarityMetric):
         feature_extractor: FeatureExtractorBase | None = None,
         clustering_model: ClusteringModelBase | None = None,
         weights: KMeansWeights | GMMWeights | None = None,
-        similarity_func: Callable[
-            [np.ndarray, np.ndarray], np.ndarray
-        ] = cosine_similarity,
+        similarity_func: SimilarityFunc = cosine_similarity,
         power_norm_weight: float = 1,
         norm_order: int = 2,
         epsilon: float = 1e-9,
@@ -275,7 +278,7 @@ class ImageEncoderBase(SimilarityMetric):
         self._feature_extractor: FeatureExtractorBase
         self._clustering_model: ClusteringModelBase | None = None
         self._pca: PCA | None = None
-        self._similarity_func: Callable[[np.ndarray, np.ndarray], np.ndarray]
+        self._similarity_func: SimilarityFunc
 
         self.power_norm_weight = power_norm_weight
         self.norm_order = norm_order
@@ -343,13 +346,11 @@ class ImageEncoderBase(SimilarityMetric):
         self._feature_extractor = feature_extractor
 
     @property
-    def similarity_func(self) -> Callable[[np.ndarray, np.ndarray], np.ndarray]:
+    def similarity_func(self) -> SimilarityFunc:
         return self._similarity_func
 
     @similarity_func.setter
-    def similarity_func(
-        self, func: Callable[[np.ndarray, np.ndarray], np.ndarray]
-    ) -> None:
+    def similarity_func(self, func: SimilarityFunc) -> None:
         dummy1, dummy2 = np.random.rand(10, 10), np.random.rand(10, 10)
         self._similarity_func = check_desired_output(func, dummy1, dummy2)
 
@@ -473,7 +474,7 @@ class ImageEncoderBase(SimilarityMetric):
                 "This encoder has no clustering model to fit. "
                 "Configure one via the constructor parameters."
             )
-        features = np.vstack(
+        features: FloatNumpyArray = np.vstack(
             [
                 self.feature_extractor(image)
                 for image in iter_images(images, dims=dims, value_range=value_range)
@@ -538,9 +539,7 @@ class ImageEncoderBase(SimilarityMetric):
         path: str | pathlib.Path,
         *,
         feature_extractor: FeatureExtractorBase | None = None,
-        similarity_func: Callable[
-            [np.ndarray, np.ndarray], np.ndarray
-        ] = cosine_similarity,
+        similarity_func: SimilarityFunc = cosine_similarity,
     ) -> _EncoderT:
         """
         Loads an encoder previously saved with :meth:`save_to_disk`.
@@ -584,7 +583,7 @@ class ImageEncoderBase(SimilarityMetric):
     # @lru_cache(maxsize=4)
     def generate_encoding_map(
         self, image_paths: Iterable[str], /
-    ) -> dict[str, np.ndarray]:
+    ) -> dict[str, FloatNumpyArray]:
         """
         Converts a collection of image file paths into a dictionary of
         ``{image_path: encoded_vector}``.
@@ -606,7 +605,7 @@ class ImageEncoderBase(SimilarityMetric):
         *,
         dims: str = "HWC",
         value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> np.ndarray:
+    ) -> FloatNumpyArray:
         """
         Encodes one or more images into a batch of vector representations.
 
@@ -637,7 +636,7 @@ class ImageEncoderBase(SimilarityMetric):
         *,
         dims: str = "HWC",
         value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> np.ndarray:
+    ) -> Float32NumpyArray:
         """
         Computes vector encodings for two images and calculates the similarity score between them.
 

--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -15,6 +15,8 @@ from .._config import PICKLE_MODEL_FILES_PATH, setup_logging
 from .._utils import cosine_similarity, read_image_rgb
 from ..clustering import PCA, ClusteringModelBase
 from ..features._features import RootSIFT
+from ..typing import ImageInput
+from .utils import iter_images
 
 setup_logging()
 
@@ -431,10 +433,12 @@ class ImageEncoderBase(SimilarityMetric):
 
     def learn(
         self,
-        images: Iterable[np.ndarray],
+        images: ImageInput,
         /,
         *,
         dim_reduction_factor: int | None = None,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
     ) -> None:
         """
         Learns the visual vocabulary from the given images.
@@ -444,8 +448,19 @@ class ImageEncoderBase(SimilarityMetric):
         on the extracted features. If a PCA model is configured, the features
         are reduced with it first (fitting it beforehand if necessary).
 
-        :param images: An iterable of images.
+        :param images: A single ``MatLike`` image, a batched array, or an
+            iterable of images. Each image is normalized to a canonical
+            ``uint8`` ``(H, W, C)`` array before feature extraction.
         :param dim_reduction_factor: If a value is provided, a new PCA model will be used to reduce the dimensionality of the feature space
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
+            (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
+            width × channels (NumPy/OpenCV single-image layout, **default**);
+            ``"CHW"`` is channels × height × width (PyTorch single-image layout);
+            ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
+            See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in;
+            converted into the canonical ``[0, 255]`` range.
         :raises RuntimeError: If the encoder has no clustering model configured.
         :raises ValueError: If dim_reduction_factor is provided but is not a positive integer.
         """
@@ -458,7 +473,12 @@ class ImageEncoderBase(SimilarityMetric):
                 "This encoder has no clustering model to fit. "
                 "Configure one via the constructor parameters."
             )
-        features = np.vstack([self.feature_extractor(image) for image in images])
+        features = np.vstack(
+            [
+                self.feature_extractor(image)
+                for image in iter_images(images, dims=dims, value_range=value_range)
+            ]
+        )
         print("[INFO] Learning the visual vocabulary with the following parameters:")
         print("   - Number of clusters:", self._clustering_model.n_clusters)
         print("   - Feature Extractor used:", self.feature_extractor.__class__.__name__)
@@ -580,29 +600,62 @@ class ImageEncoderBase(SimilarityMetric):
         return dict(zip(image_paths, self.encode(images), strict=True))
 
     @abc.abstractmethod
-    def encode(self, images: Iterable[np.ndarray] | np.ndarray) -> np.ndarray:
+    def encode(
+        self,
+        images: ImageInput,
+        *,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
+    ) -> np.ndarray:
         """
         Encodes one or more images into a batch of vector representations.
 
-        :param images: iterable. Consider using an iterator if you have a lot of images.
+        Each image is normalized to a canonical ``uint8`` ``(H, W, C)`` array
+        before feature extraction, so NumPy arrays, torch tensors and other
+        array-like inputs are all accepted. When a batch axis is present (via
+        ``dims``), every image in the batch is encoded.
+
+        :param images: A single ``MatLike`` image, a batched array, or an
+            iterable of images. Consider using an iterator for large datasets.
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
+            (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
+            width × channels (NumPy/OpenCV single-image layout, **default**);
+            ``"CHW"`` is channels × height × width (PyTorch single-image layout);
+            ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
+            See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in;
+            converted into the canonical ``[0, 255]`` range.
         :return: vector representations of the given images
         """
         raise NotImplementedError
 
     def similarity_score(
         self,
-        images1: Iterable[np.ndarray] | np.ndarray,
-        images2: Iterable[np.ndarray] | np.ndarray,
+        images1: ImageInput,
+        images2: ImageInput,
+        *,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
     ) -> np.ndarray:
         """
         Computes vector encodings for two images and calculates the similarity score between them.
 
-        :param images1: First (batch of) image(s)
-        :param images2: Second (batch of) image(s)
+        :param images1: First (batch of) image(s) as ``MatLike``.
+        :param images2: Second (batch of) image(s) as ``MatLike``.
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
+            (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
+            width × channels (NumPy/OpenCV single-image layout, **default**);
+            ``"CHW"`` is channels × height × width (PyTorch single-image layout);
+            ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
+            See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in;
+            converted into the canonical ``[0, 255]`` range.
         :return: Similarity matrix between the two image batches.
         """
-        vector1 = self.encode(images1)
-        vector2 = self.encode(images2)
+        vector1 = self.encode(images1, dims=dims, value_range=value_range)
+        vector2 = self.encode(images2, dims=dims, value_range=value_range)
         result = self.similarity_func(vector1, vector2)
         return np.asarray(result, dtype=np.float32)
 

--- a/pyvisim/encoders/fisher_vector.py
+++ b/pyvisim/encoders/fisher_vector.py
@@ -1,13 +1,14 @@
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from typing import Any, cast
 
 import numpy as np
-import torch
 
 from .._base_classes import FeatureExtractorBase
 from .._utils import cosine_similarity
 from ..clustering import PCA, ClusteringModelBase, GaussianMixtureModel
 from ..encoders._base_encoder import GMMWeights, ImageEncoderBase
+from ..typing import ImageInput
+from .utils import iter_images
 
 
 class FisherVectorEncoder(ImageEncoderBase):
@@ -106,13 +107,32 @@ class FisherVectorEncoder(ImageEncoderBase):
             )
         self._set_clustering_model(model)
 
-    def encode(self, images: Iterable[np.ndarray] | np.ndarray) -> np.ndarray:
+    def encode(
+        self,
+        images: ImageInput,
+        *,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
+    ) -> np.ndarray:
+        """
+        Encode one or more images into Fisher Vector descriptors.
+
+        :param images: A single ``MatLike`` image, a batched array, or an
+            iterable of images.
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
+            (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
+            width × channels (NumPy/OpenCV single-image layout, **default**);
+            ``"CHW"`` is channels × height × width (PyTorch single-image layout);
+            ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
+            See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in;
+            converted into the canonical ``[0, 255]`` range.
+        :return: ``(N, 2 × n_components × feature_dim + n_components)`` array of
+            Fisher Vector encodings.
+        """
         all_encodings = []
-        if isinstance(images, torch.Tensor):
-            raise RuntimeError("Torch images are not supported yet.")
-        if isinstance(images, np.ndarray) and images.ndim == 3:
-            images = [images]  # Handle single image case
-        for image in images:
+        for image in iter_images(images, dims=dims, value_range=value_range):
             descriptors = self.feature_extractor(image)
             if self.pca:
                 descriptors = self.pca.transform(descriptors.astype(np.float32))

--- a/pyvisim/encoders/fisher_vector.py
+++ b/pyvisim/encoders/fisher_vector.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from typing import Any, cast
 
 import numpy as np
@@ -7,7 +6,12 @@ from .._base_classes import FeatureExtractorBase
 from .._utils import cosine_similarity
 from ..clustering import PCA, ClusteringModelBase, GaussianMixtureModel
 from ..encoders._base_encoder import GMMWeights, ImageEncoderBase
-from ..typing import ImageInput
+from ..typing import (
+    Float64NumpyArray,
+    FloatNumpyArray,
+    ImageInput,
+    SimilarityFunc,
+)
 from .utils import iter_images
 
 
@@ -62,9 +66,7 @@ class FisherVectorEncoder(ImageEncoderBase):
         norm_order: int = 2,
         epsilon: float = 1e-9,
         flatten: bool = True,
-        similarity_func: Callable[
-            [np.ndarray, np.ndarray], np.ndarray
-        ] = cosine_similarity,
+        similarity_func: SimilarityFunc = cosine_similarity,
         raise_error_when_pca_incompatible: bool = False,
     ):
         if weights is not None:
@@ -113,7 +115,7 @@ class FisherVectorEncoder(ImageEncoderBase):
         *,
         dims: str = "HWC",
         value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> np.ndarray:
+    ) -> Float64NumpyArray:
         """
         Encode one or more images into Fisher Vector descriptors.
 
@@ -133,7 +135,7 @@ class FisherVectorEncoder(ImageEncoderBase):
         """
         all_encodings = []
         for image in iter_images(images, dims=dims, value_range=value_range):
-            descriptors = self.feature_extractor(image)
+            descriptors: FloatNumpyArray = self.feature_extractor(image)
             if self.pca:
                 descriptors = self.pca.transform(descriptors.astype(np.float32))
             num_descriptors = len(descriptors)

--- a/pyvisim/encoders/pipeline.py
+++ b/pyvisim/encoders/pipeline.py
@@ -1,13 +1,13 @@
 import logging
 from collections.abc import Callable, Iterable
-from itertools import tee
 
 import numpy as np
-import torch
 
 from .._base_classes import SimilarityMetric
 from .._utils import cosine_similarity, read_image_rgb
+from ..typing import ImageInput
 from ._base_encoder import ImageEncoderBase, check_desired_output
+from .utils import iter_images
 
 
 class Pipeline(SimilarityMetric):
@@ -48,23 +48,41 @@ class Pipeline(SimilarityMetric):
                     f"Pipeline only accepts instances of ImageEncoderBase, not {type(encoder)}"
                 )
 
-    def encode(self, images: Iterable[np.ndarray] | np.ndarray) -> np.ndarray:
+    def encode(
+        self,
+        images: ImageInput,
+        *,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
+    ) -> np.ndarray:
         """
         Encode an image using all encoders in the pipeline.
 
-        :param images: Images to process.
+        The input is normalized once into canonical ``uint8`` ``(H, W, C)``
+        images (handling torch tensors and batches), then shared across every
+        encoder in the pipeline.
+
+        :param images: A single ``MatLike`` image, a batched array, or an
+            iterable of images.
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
+            (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
+            width × channels (NumPy/OpenCV single-image layout, **default**);
+            ``"CHW"`` is channels × height × width (PyTorch single-image layout);
+            ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
+            See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in;
+            converted into the canonical ``[0, 255]`` range.
         :return: encoded images using the combined encoders.
         """
+        image_list = list(iter_images(images, dims=dims, value_range=value_range))
         all_encodings = []
-        if isinstance(images, torch.Tensor):
-            raise RuntimeError("Torch images are not supported yet.")
-        if isinstance(images, np.ndarray) and images.ndim == 3:
-            images = [images]  # Handle single image case
-        images_gen = tee(images, len(self.encoders))
-        for metric, images in zip(self.encoders, images_gen, strict=True):
+        for metric in self.encoders:
             a = metric.flatten  # each encoder has to be flattened to be usable here. Saving the original state temporarily
             metric.flatten = True
-            encodings = metric.encode(images)  # Each of size (num_imgs, feature_dim)
+            encodings = metric.encode(
+                image_list
+            )  # Each of size (num_imgs, feature_dim)
             all_encodings.append(encodings)
             metric.flatten = a
         return np.hstack(all_encodings)
@@ -99,18 +117,30 @@ class Pipeline(SimilarityMetric):
 
     def similarity_score(
         self,
-        images1: Iterable[np.ndarray] | np.ndarray,
-        images2: Iterable[np.ndarray] | np.ndarray,
+        images1: ImageInput,
+        images2: ImageInput,
+        *,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
     ) -> np.ndarray:
         """
         Computes vector encodings for two images and calculates the similarity score between them.
 
-        :param images1: First (batch of) image(s)
-        :param images2: Second (batch of) image(s)
+        :param images1: First (batch of) image(s) as ``MatLike``.
+        :param images2: Second (batch of) image(s) as ``MatLike``.
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
+            (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
+            width × channels (NumPy/OpenCV single-image layout, **default**);
+            ``"CHW"`` is channels × height × width (PyTorch single-image layout);
+            ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
+            See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in;
+            converted into the canonical ``[0, 255]`` range.
         :return: Similarity matrix between the two image batches.
         """
-        vector1 = self.encode(images1)
-        vector2 = self.encode(images2)
+        vector1 = self.encode(images1, dims=dims, value_range=value_range)
+        vector2 = self.encode(images2, dims=dims, value_range=value_range)
         result = self.similarity_func(vector1, vector2)
         return np.asarray(result, dtype=np.float32)
 

--- a/pyvisim/encoders/pipeline.py
+++ b/pyvisim/encoders/pipeline.py
@@ -1,11 +1,16 @@
 import logging
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 
 import numpy as np
 
 from .._base_classes import SimilarityMetric
 from .._utils import cosine_similarity, read_image_rgb
-from ..typing import ImageInput
+from ..typing import (
+    Float32NumpyArray,
+    FloatNumpyArray,
+    ImageInput,
+    SimilarityFunc,
+)
 from ._base_encoder import ImageEncoderBase, check_desired_output
 from .utils import iter_images
 
@@ -29,9 +34,7 @@ class Pipeline(SimilarityMetric):
     def __init__(
         self,
         encoders: list[ImageEncoderBase],
-        similarity_func: Callable[
-            [np.ndarray, np.ndarray], np.ndarray
-        ] = cosine_similarity,
+        similarity_func: SimilarityFunc = cosine_similarity,
     ):
         self._check_valid_encoders(encoders)
         self.encoders = encoders
@@ -54,7 +57,7 @@ class Pipeline(SimilarityMetric):
         *,
         dims: str = "HWC",
         value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> np.ndarray:
+    ) -> FloatNumpyArray:
         """
         Encode an image using all encoders in the pipeline.
 
@@ -89,7 +92,7 @@ class Pipeline(SimilarityMetric):
 
     def generate_encoding_map(
         self, image_paths: Iterable[str]
-    ) -> dict[str, np.ndarray]:
+    ) -> dict[str, FloatNumpyArray]:
         """
         Converts a collection of image file paths into a dictionary of
         ``{image_path: encoded_vector}``.
@@ -105,13 +108,11 @@ class Pipeline(SimilarityMetric):
         return dict(zip(image_paths, self.encode(images), strict=True))
 
     @property
-    def similarity_func(self) -> Callable[[np.ndarray, np.ndarray], np.ndarray]:
+    def similarity_func(self) -> SimilarityFunc:
         return self._similarity_func
 
     @similarity_func.setter
-    def similarity_func(
-        self, func: Callable[[np.ndarray, np.ndarray], np.ndarray]
-    ) -> None:
+    def similarity_func(self, func: SimilarityFunc) -> None:
         dummy1, dummy2 = np.random.rand(10, 10), np.random.rand(10, 10)
         self._similarity_func = check_desired_output(func, dummy1, dummy2)
 
@@ -122,7 +123,7 @@ class Pipeline(SimilarityMetric):
         *,
         dims: str = "HWC",
         value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> np.ndarray:
+    ) -> Float32NumpyArray:
         """
         Computes vector encodings for two images and calculates the similarity score between them.
 

--- a/pyvisim/encoders/utils.py
+++ b/pyvisim/encoders/utils.py
@@ -1,0 +1,47 @@
+from collections.abc import Iterable, Iterator
+
+import numpy as np
+import torch
+
+from .._errors import InvalidImageError
+from ..typing import ImageInput, _to_image_list
+
+
+def iter_images(
+    images: ImageInput,
+    dims: str = "HWC",
+    value_range: tuple[float, float] = (0.0, 255.0),
+) -> Iterator[np.ndarray]:
+    """
+    Yield canonical per-image arrays from a single object or an iterable.
+
+    A single (possibly batched) ``MatLike`` array/tensor is normalized and its
+    images are yielded. Any other iterable is treated as a collection of
+    ``MatLike`` images, each of which is normalized in turn; if its elements
+    carry a batch axis (per ``dims``), every image is still yielded, so a batch
+    size is handled gracefully.
+
+    :param images: A single ``MatLike`` object or an iterable of ``MatLike`` images.
+    :param dims: Axis-label string, one character per array axis in order:
+        ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
+        (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
+        width × channels (NumPy/OpenCV single-image layout, **default**);
+        ``"CHW"`` is channels × height × width (PyTorch single-image layout);
+        ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
+    :param value_range: The ``(low, high)`` range the input values live in
+        (default ``(0.0, 255.0)``).
+    :return: An iterator over ``uint8`` images of shape ``(H, W[, C])``.
+    :raises InvalidImageError: If a string/bytes object is passed as an image.
+    """
+    if not isinstance(images, (np.ndarray, torch.Tensor, Iterable)):
+        raise InvalidImageError(
+            f"Expected image array(s), but got a {type(images).__name__} object."
+        )
+    if isinstance(images, (np.ndarray, torch.Tensor)):
+        yield from _to_image_list(images, dims, value_range)
+        return
+    if isinstance(images, Iterable):
+        for image in images:
+            yield from _to_image_list(image, dims, value_range)
+        return
+    yield from _to_image_list(images, dims, value_range)

--- a/pyvisim/encoders/utils.py
+++ b/pyvisim/encoders/utils.py
@@ -5,14 +5,14 @@ import torch
 
 from .._errors import InvalidImageError
 from ..features._features import grayscale_dims
-from ..typing import ImageInput, _to_image_list
+from ..typing import ImageInput, UInt8NumpyArray, _to_image_list
 
 
 def iter_images(
     images: ImageInput,
     dims: str = "HWC",
     value_range: tuple[float, float] = (0.0, 255.0),
-) -> Iterator[np.ndarray]:
+) -> Iterator[UInt8NumpyArray]:
     """
     Yield canonical per-image arrays from a single object or an iterable.
 

--- a/pyvisim/encoders/utils.py
+++ b/pyvisim/encoders/utils.py
@@ -4,6 +4,7 @@ import numpy as np
 import torch
 
 from .._errors import InvalidImageError
+from ..features._features import grayscale_dims
 from ..typing import ImageInput, _to_image_list
 
 
@@ -42,6 +43,6 @@ def iter_images(
         return
     if isinstance(images, Iterable):
         for image in images:
-            yield from _to_image_list(image, dims, value_range)
+            yield from _to_image_list(image, grayscale_dims(image, dims), value_range)
         return
     yield from _to_image_list(images, dims, value_range)

--- a/pyvisim/encoders/vlad.py
+++ b/pyvisim/encoders/vlad.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from typing import Any, cast
 
 import numpy as np
@@ -7,7 +6,12 @@ from .._base_classes import FeatureExtractorBase
 from .._utils import cosine_similarity
 from ..clustering import PCA, ClusteringModelBase, KMeans
 from ..encoders._base_encoder import ImageEncoderBase, KMeansWeights
-from ..typing import ImageInput
+from ..typing import (
+    Float32NumpyArray,
+    FloatNumpyArray,
+    ImageInput,
+    SimilarityFunc,
+)
 from .utils import iter_images
 
 
@@ -67,9 +71,7 @@ class VLADEncoder(ImageEncoderBase):
         norm_order: int = 2,
         epsilon: float = 1e-9,
         flatten: bool = True,
-        similarity_func: Callable[
-            [np.ndarray, np.ndarray], np.ndarray
-        ] = cosine_similarity,
+        similarity_func: SimilarityFunc = cosine_similarity,
         raise_error_when_pca_incompatible: bool = False,
     ) -> None:
         if weights is not None:
@@ -118,7 +120,7 @@ class VLADEncoder(ImageEncoderBase):
         *,
         dims: str = "HWC",
         value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> np.ndarray:
+    ) -> Float32NumpyArray:
         """
         Encode one or more images into VLAD descriptor vectors.
 
@@ -137,7 +139,7 @@ class VLADEncoder(ImageEncoderBase):
         """
         all_encodings = []
         for image in iter_images(images, dims=dims, value_range=value_range):
-            descriptors = self.feature_extractor(image)
+            descriptors: FloatNumpyArray = self.feature_extractor(image)
             if self.pca:
                 descriptors = self.pca.transform(descriptors.astype(np.float32))
 
@@ -151,7 +153,7 @@ class VLADEncoder(ImageEncoderBase):
 
             k = len(centroids)
             dim = descriptors.shape[1]
-            descriptor_vector: np.ndarray = np.zeros((k, dim), dtype=np.float32)
+            descriptor_vector: FloatNumpyArray = np.zeros((k, dim), dtype=np.float32)
 
             for i, desc in enumerate(descriptors):
                 cluster_id = labels[i]

--- a/pyvisim/encoders/vlad.py
+++ b/pyvisim/encoders/vlad.py
@@ -1,13 +1,14 @@
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from typing import Any, cast
 
 import numpy as np
-import torch
 
 from .._base_classes import FeatureExtractorBase
 from .._utils import cosine_similarity
 from ..clustering import PCA, ClusteringModelBase, KMeans
 from ..encoders._base_encoder import ImageEncoderBase, KMeansWeights
+from ..typing import ImageInput
+from .utils import iter_images
 
 
 class VLADEncoder(ImageEncoderBase):
@@ -111,13 +112,31 @@ class VLADEncoder(ImageEncoderBase):
             )
         self._set_clustering_model(model)
 
-    def encode(self, images: Iterable[np.ndarray] | np.ndarray) -> np.ndarray:
+    def encode(
+        self,
+        images: ImageInput,
+        *,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
+    ) -> np.ndarray:
+        """
+        Encode one or more images into VLAD descriptor vectors.
+
+        :param images: A single ``MatLike`` image, a batched array, or an
+            iterable of images.
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
+            (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
+            width × channels (NumPy/OpenCV single-image layout, **default**);
+            ``"CHW"`` is channels × height × width (PyTorch single-image layout);
+            ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
+            See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in;
+            converted into the canonical ``[0, 255]`` range.
+        :return: ``(N, n_clusters × feature_dim)`` array of VLAD encodings.
+        """
         all_encodings = []
-        if isinstance(images, torch.Tensor):
-            raise RuntimeError("Torch images are not supported yet.")
-        if isinstance(images, np.ndarray) and images.ndim == 3:
-            images = [images]  # Handle single image case
-        for image in images:
+        for image in iter_images(images, dims=dims, value_range=value_range):
             descriptors = self.feature_extractor(image)
             if self.pca:
                 descriptors = self.pca.transform(descriptors.astype(np.float32))

--- a/pyvisim/eval.py
+++ b/pyvisim/eval.py
@@ -8,6 +8,7 @@ from typing import Protocol
 import numpy as np
 
 from ._utils import cosine_similarity
+from .typing import ImageInput
 
 __all__ = ["retrieve_top_k_similar", "top_k_map", "top_k_accuracy"]
 
@@ -15,11 +16,25 @@ __all__ = ["retrieve_top_k_similar", "top_k_map", "top_k_accuracy"]
 class Encoder(Protocol):
     """Any object that can encode images into vector representations."""
 
-    def encode(self, images: Iterable[np.ndarray] | np.ndarray) -> np.ndarray:
+    def encode(
+        self,
+        images: ImageInput,
+        *,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
+    ) -> np.ndarray:
         """
         Encodes one or more images into a batch of vector representations.
 
-        :param images: One image or an iterable of images.
+        :param images: One ``MatLike`` image or an iterable of images.
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
+            (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
+            width × channels (NumPy/OpenCV single-image layout, **default**);
+            ``"CHW"`` is channels × height × width (PyTorch single-image layout);
+            ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
+            See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in.
         :return: Vector representations of the given images.
         """
         ...

--- a/pyvisim/eval.py
+++ b/pyvisim/eval.py
@@ -8,7 +8,7 @@ from typing import Protocol
 import numpy as np
 
 from ._utils import cosine_similarity
-from .typing import ImageInput
+from .typing import FloatNumpyArray, ImageInput, NumpyArray
 
 __all__ = ["retrieve_top_k_similar", "top_k_map", "top_k_accuracy"]
 
@@ -22,7 +22,7 @@ class Encoder(Protocol):
         *,
         dims: str = "HWC",
         value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> np.ndarray:
+    ) -> FloatNumpyArray:
         """
         Encodes one or more images into a batch of vector representations.
 
@@ -41,8 +41,8 @@ class Encoder(Protocol):
 
 
 def retrieve_top_k_similar(
-    uploaded_image: np.ndarray,
-    dataset: dict[str, np.ndarray],
+    uploaded_image: NumpyArray,
+    dataset: dict[str, FloatNumpyArray],
     encoder: Encoder,
     k: int = 5,
 ) -> list[tuple[str, float]]:
@@ -77,9 +77,9 @@ def retrieve_top_k_similar(
 
 
 def top_k_map(
-    images: Iterable[np.ndarray],
+    images: Iterable[NumpyArray],
     image_labels: Iterable[int],
-    encoding_map: dict[str, np.ndarray],
+    encoding_map: dict[str, FloatNumpyArray],
     path_labels_dict: dict[str, int],
     encoder: Encoder,
     k: int | None = None,
@@ -136,9 +136,9 @@ def top_k_map(
 
 
 def top_k_accuracy(
-    images: Iterable[np.ndarray],
+    images: Iterable[NumpyArray],
     image_labels: Iterable[int],
-    encoding_map: dict[str, np.ndarray],
+    encoding_map: dict[str, FloatNumpyArray],
     path_labels_dict: dict[str, int],
     encoder: Encoder,
     k: int,

--- a/pyvisim/features/_features.py
+++ b/pyvisim/features/_features.py
@@ -18,11 +18,42 @@ from torchvision.models import VGG16_Weights, vgg16
 
 from .._base_classes import FeatureExtractorBase
 from .._config import setup_logging
+from ..typing import MatLike, _to_image_list
 
 setup_logging()
 
 
 ExtractorCallT = TypeVar("ExtractorCallT", bound=Callable[..., Any])
+
+
+def _to_single_image(
+    image: MatLike,
+    dims: str = "HWC",
+    value_range: tuple[float, float] = (0.0, 255.0),
+) -> np.ndarray:
+    """
+    Normalize a single ``MatLike`` image into one canonical array.
+
+    :param image: A NumPy array, a PyTorch tensor, or any array-like object.
+    :param dims: Axis-label string, one character per array axis in order:
+        ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
+        (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
+        width × channels (NumPy/OpenCV single-image layout, **default**);
+        ``"CHW"`` is channels × height × width (PyTorch single-image layout);
+        ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
+    :param value_range: The ``(low, high)`` range the input values live in
+        (default ``(0.0, 255.0)``).
+    :return: A ``uint8`` image of shape ``(H, W[, C])`` in ``[0, 255]``.
+    :raises ValueError: If the input expands to anything other than one image.
+    """
+    images = _to_image_list(image, dims, value_range)
+    if len(images) != 1:
+        raise ValueError(
+            f"Expected a single image, but the input expands to {len(images)} images. "
+            "Feature extractors operate on one image at a time; use an encoder for "
+            "batches."
+        )
+    return images[0]
 
 
 def _check_output_shape(  # noqa: UP047
@@ -31,15 +62,17 @@ def _check_output_shape(  # noqa: UP047
     """
     Ensures the feature extractor output is a 2D NumPy array of shape
     (num_vectors, self.output_dim).
+
+    Input normalization (``MatLike`` conversion plus ``dims``/``value_range``
+    handling) is performed inside each wrapped ``__call__``; this decorator
+    only validates the output.
     """
 
     @wraps(func)
-    def wrapper(self: FeatureExtractorBase, image: np.ndarray, /) -> np.ndarray:
-        if isinstance(image, torch.Tensor):
-            raise TypeError(
-                "Currently, only Torch images are not supported yet. Please convert to NumPy."
-            )
-        feat_vecs = func(self, image)
+    def wrapper(
+        self: FeatureExtractorBase, image: MatLike, /, *args: Any, **kwargs: Any
+    ) -> np.ndarray:
+        feat_vecs = func(self, image, *args, **kwargs)
         if feat_vecs is None:
             print("No feature vectors found. Returning empty array.")
             return np.zeros((0, self.output_dim), dtype=np.float32)
@@ -83,12 +116,27 @@ class SIFT(FeatureExtractorBase):
         return self._output_dim
 
     @_check_output_shape
-    def __call__(self, image: np.ndarray, /) -> np.ndarray:
+    def __call__(
+        self,
+        image: MatLike,
+        /,
+        *,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
+    ) -> np.ndarray:
         """
         Extracts SIFT features from an image.
-        :param image:
-        :return:
+
+        :param image: Input image as ``MatLike``.
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels.
+            For example, ``"HWC"`` is height × width × channels (NumPy/OpenCV
+            layout, **default**); ``"CHW"`` is channels × height × width (PyTorch
+            layout). See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in.
+        :return: ``(num_keypoints, 128)`` array of SIFT descriptors.
         """
+        image = _to_single_image(image, dims=dims, value_range=value_range)
         sift = cv2.SIFT.create()
         _, descriptors = sift.detectAndCompute(image, None)
         return descriptors
@@ -115,12 +163,27 @@ class RootSIFT(FeatureExtractorBase):
         return self._output_dim
 
     @_check_output_shape
-    def __call__(self, image: np.ndarray, /) -> np.ndarray:
+    def __call__(
+        self,
+        image: MatLike,
+        /,
+        *,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
+    ) -> np.ndarray:
         """
         Extracts RootSIFT features from an image.
-        :param image:
-        :return:
+
+        :param image: Input image as ``MatLike``.
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels.
+            For example, ``"HWC"`` is height × width × channels (NumPy/OpenCV
+            layout, **default**); ``"CHW"`` is channels × height × width (PyTorch
+            layout). See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in.
+        :return: ``(num_keypoints, 128)`` array of RootSIFT descriptors.
         """
+        image = _to_single_image(image, dims=dims, value_range=value_range)
         sift = cv2.SIFT.create()
         _, descriptors = sift.detectAndCompute(image, None)
         if descriptors is not None:
@@ -160,7 +223,27 @@ class Lambda(FeatureExtractorBase):
         return self._output_dim
 
     @_check_output_shape
-    def __call__(self, image: np.ndarray, /) -> np.ndarray:
+    def __call__(
+        self,
+        image: MatLike,
+        /,
+        *,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
+    ) -> np.ndarray:
+        """
+        Extracts features from an image using the user-defined function.
+
+        :param image: Input image as ``MatLike``.
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels.
+            For example, ``"HWC"`` is height × width × channels (NumPy/OpenCV
+            layout, **default**); ``"CHW"`` is channels × height × width (PyTorch
+            layout). See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in.
+        :return: Feature descriptors returned by ``func``.
+        """
+        image = _to_single_image(image, dims=dims, value_range=value_range)
         return self.func(image)
 
 
@@ -311,22 +394,40 @@ class DeepConvFeature(FeatureExtractorBase):
         self.hook = self.selected_layer_module.register_forward_hook(hook_fn)
 
     @_check_output_shape
-    def __call__(self, image: np.ndarray, /) -> np.ndarray:
+    def __call__(
+        self,
+        image: MatLike,
+        /,
+        *,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
+    ) -> np.ndarray:
         """
-        #TODO: first, check if image is tensor and has range [0,1]. If numpy and has range [0,255], normalize and convert to tensor. If numpy and has range [0,1], convert to tensor. Else, raise error.
-        #TODO: add support for batch processing
         Processes a single image through the chosen conv layer and
         returns flattened feature descriptors.
 
-        :param image: Input image as a NumPy array (H x W x C, BGR or RGB).
+        The input is normalized to a canonical ``uint8`` ``(H, W, C)`` image
+        and then passed through ``self.transform`` (which converts it to a
+        tensor in ``[0, 1]``). Batches are handled at the encoder level, so a
+        single image is expected here.
+
+        :param image: Input image as ``MatLike`` (e.g. a NumPy ``(H, W, C)``
+            array or a torch ``(C, H, W)`` tensor; pass ``dims`` accordingly).
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels.
+            For example, ``"HWC"`` is height × width × channels (NumPy/OpenCV
+            layout, **default**); ``"CHW"`` is channels × height × width (PyTorch
+            layout). See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in.
         :return: N x D NumPy array, where N = (H_conv x W_conv) and
                  D = number_of_channels (+ 2 if spatial coords are appended).
         """
-        image = self.transform(image).unsqueeze(0).to(self.device)
+        image = _to_single_image(image, dims=dims, value_range=value_range)
+        input_tensor = self.transform(image).unsqueeze(0).to(self.device)
 
         self.model.eval()
         self.model.to(self.device)
-        _ = self.model(image)  # we only care about the hook's output
+        _ = self.model(input_tensor)  # we only care about the hook's output
         if self.buffer is None:
             raise RuntimeError("Forward hook did not capture any features.")
 

--- a/pyvisim/features/_features.py
+++ b/pyvisim/features/_features.py
@@ -26,6 +26,30 @@ setup_logging()
 ExtractorCallT = TypeVar("ExtractorCallT", bound=Callable[..., Any])
 
 
+def grayscale_dims(image: MatLike, dims: str) -> str:
+    """
+    Drop the channel label from ``dims`` for a single-channel (grayscale) image.
+
+    A grayscale image carries no channel axis, so an array with exactly one
+    fewer dimension than a channel-bearing ``dims`` (e.g. a 2-D array with the
+    default ``"HWC"``) is treated as single-channel and the ``"C"`` label is
+    removed. This keeps the canonical ``(H, W)`` grayscale layout working with
+    the channel-bearing default, matching the NumPy-only behaviour the library
+    accepted before ``dims`` were introduced.
+
+    :param image: The image whose axis count is inspected.
+    :param dims: The requested axis-label string.
+    :return: ``dims`` with ``"C"`` removed when ``image`` is single-channel,
+        otherwise ``dims`` unchanged.
+    """
+    normalized = dims.upper()
+    if "C" not in normalized:
+        return dims
+    if np.ndim(image) == len(normalized) - 1:
+        return normalized.replace("C", "")
+    return dims
+
+
 def _to_single_image(
     image: MatLike,
     dims: str = "HWC",
@@ -41,12 +65,14 @@ def _to_single_image(
         width × channels (NumPy/OpenCV single-image layout, **default**);
         ``"CHW"`` is channels × height × width (PyTorch single-image layout);
         ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
+        A single-channel (grayscale) image may be passed as a 2-D array with the
+        default ``"HWC"``; the channel label is dropped automatically.
     :param value_range: The ``(low, high)`` range the input values live in
         (default ``(0.0, 255.0)``).
     :return: A ``uint8`` image of shape ``(H, W[, C])`` in ``[0, 255]``.
     :raises ValueError: If the input expands to anything other than one image.
     """
-    images = _to_image_list(image, dims, value_range)
+    images = _to_image_list(image, grayscale_dims(image, dims), value_range)
     if len(images) != 1:
         raise ValueError(
             f"Expected a single image, but the input expands to {len(images)} images. "

--- a/pyvisim/features/_features.py
+++ b/pyvisim/features/_features.py
@@ -18,7 +18,12 @@ from torchvision.models import VGG16_Weights, vgg16
 
 from .._base_classes import FeatureExtractorBase
 from .._config import setup_logging
-from ..typing import MatLike, _to_image_list
+from ..typing import (
+    Float32NumpyArray,
+    MatLike,
+    UInt8NumpyArray,
+    _to_image_list,
+)
 
 setup_logging()
 
@@ -54,7 +59,7 @@ def _to_single_image(
     image: MatLike,
     dims: str = "HWC",
     value_range: tuple[float, float] = (0.0, 255.0),
-) -> np.ndarray:
+) -> UInt8NumpyArray:
     """
     Normalize a single ``MatLike`` image into one canonical array.
 
@@ -97,7 +102,7 @@ def _check_output_shape(  # noqa: UP047
     @wraps(func)
     def wrapper(
         self: FeatureExtractorBase, image: MatLike, /, *args: Any, **kwargs: Any
-    ) -> np.ndarray:
+    ) -> Float32NumpyArray:
         feat_vecs = func(self, image, *args, **kwargs)
         if feat_vecs is None:
             print("No feature vectors found. Returning empty array.")
@@ -149,7 +154,7 @@ class SIFT(FeatureExtractorBase):
         *,
         dims: str = "HWC",
         value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> np.ndarray:
+    ) -> Float32NumpyArray:
         """
         Extracts SIFT features from an image.
 
@@ -165,7 +170,7 @@ class SIFT(FeatureExtractorBase):
         image = _to_single_image(image, dims=dims, value_range=value_range)
         sift = cv2.SIFT.create()
         _, descriptors = sift.detectAndCompute(image, None)
-        return descriptors
+        return cast(Float32NumpyArray, descriptors)
 
     def __repr__(self) -> str:
         return f"SIFT(output_dim={self.output_dim})"
@@ -196,7 +201,7 @@ class RootSIFT(FeatureExtractorBase):
         *,
         dims: str = "HWC",
         value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> np.ndarray:
+    ) -> Float32NumpyArray:
         """
         Extracts RootSIFT features from an image.
 
@@ -230,7 +235,9 @@ class Lambda(FeatureExtractorBase):
     and output fixed-size feature vectors from each image.
     """
 
-    def __init__(self, func: Callable[[np.ndarray], np.ndarray], output_dim: int):
+    def __init__(
+        self, func: Callable[[UInt8NumpyArray], Float32NumpyArray], output_dim: int
+    ):
         """
         Initializes the Lambda feature extractor.
         :param func:
@@ -256,7 +263,7 @@ class Lambda(FeatureExtractorBase):
         *,
         dims: str = "HWC",
         value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> np.ndarray:
+    ) -> Float32NumpyArray:
         """
         Extracts features from an image using the user-defined function.
 
@@ -427,7 +434,7 @@ class DeepConvFeature(FeatureExtractorBase):
         *,
         dims: str = "HWC",
         value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> np.ndarray:
+    ) -> Float32NumpyArray:
         """
         Processes a single image through the chosen conv layer and
         returns flattened feature descriptors.

--- a/pyvisim/neural_networks/siamese_neural_network.py
+++ b/pyvisim/neural_networks/siamese_neural_network.py
@@ -1,16 +1,10 @@
 from collections.abc import Callable
 
-import numpy as np
-import numpy.typing as npt
 import torch
 
 from .._base_classes import SimilarityMetric
 from .._utils import cosine_similarity
-
-MatLike = np.ndarray | torch.Tensor | npt.ArrayLike
-
-
-# TODO: uncomment all "ignore" comments after implementing the class properly.
+from ..typing import MatLike, NumpyArray
 
 
 class SiameseNeuralNetwork(torch.nn.Module, SimilarityMetric):
@@ -33,7 +27,7 @@ class SiameseNeuralNetwork(torch.nn.Module, SimilarityMetric):
         image: MatLike,
         dims: str = "HWC",
         value_range: tuple[float, float] = (0, 255),
-    ) -> np.ndarray:
+    ) -> NumpyArray:
         raise NotImplementedError("SiameseNeuralNetwork is not implemented yet.")
 
     def similarity_score(  # type: ignore

--- a/pyvisim/typing/__init__.py
+++ b/pyvisim/typing/__init__.py
@@ -1,13 +1,27 @@
 """Public types used in pyvisim"""
 
 from ._typing import (
+    Float32NumpyArray,
+    Float64NumpyArray,
+    FloatNumpyArray,
     ImageInput,
+    IntNumpyArray,
     MatLike,
+    NumpyArray,
+    SimilarityFunc,
+    UInt8NumpyArray,
     _to_image_list,
 )
 
 __all__ = [
     "MatLike",
     "ImageInput",
+    "NumpyArray",
+    "UInt8NumpyArray",
+    "Float32NumpyArray",
+    "Float64NumpyArray",
+    "FloatNumpyArray",
+    "IntNumpyArray",
+    "SimilarityFunc",
     "_to_image_list",
 ]

--- a/pyvisim/typing/__init__.py
+++ b/pyvisim/typing/__init__.py
@@ -1,0 +1,13 @@
+"""Public types used in pyvisim"""
+
+from ._typing import (
+    ImageInput,
+    MatLike,
+    _to_image_list,
+)
+
+__all__ = [
+    "MatLike",
+    "ImageInput",
+    "_to_image_list",
+]

--- a/pyvisim/typing/_typing.py
+++ b/pyvisim/typing/_typing.py
@@ -46,13 +46,31 @@ provided, e.g. ``(0.0, 1.0)`` for normalized float tensors, the values are
 rescaled into the canonical ``[0, 255]`` range.
 """
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
+from typing import Any, cast
 
 import numpy as np
 import numpy.typing as npt
 import torch
 
 from .._errors import InvalidImageError
+
+#: Generic NumPy array of any dtype.
+NumpyArray = npt.NDArray[np.generic]
+#: NumPy array of uint8 values (canonical image layout).
+UInt8NumpyArray = npt.NDArray[np.uint8]
+#: NumPy array of float32 values (feature descriptors and encodings).
+Float32NumpyArray = npt.NDArray[np.float32]
+#: NumPy array of float64 values (sklearn estimator outputs).
+Float64NumpyArray = npt.NDArray[np.float64]
+#: NumPy array of any floating-point dtype.
+FloatNumpyArray = npt.NDArray[np.floating[Any]]
+#: NumPy array of platform-native signed integers (cluster labels / indices).
+IntNumpyArray = npt.NDArray[np.intp]
+
+#: A similarity function: maps two batches of feature vectors of shapes
+#: ``(N, D)`` and ``(M, D)`` to an ``(N, M)`` similarity matrix.
+SimilarityFunc = Callable[[FloatNumpyArray, FloatNumpyArray], FloatNumpyArray]
 
 #: Anything that can be turned into a numerical NumPy array: a NumPy array, a
 #: PyTorch tensor, or any array-like object (e.g. nested lists of numbers).
@@ -67,7 +85,7 @@ _CANONICAL_AXIS_ORDER = "BHWC"
 _DEFAULT_VALUE_RANGE: tuple[float, float] = (0.0, 255.0)
 
 
-def _to_ndarray(data: MatLike) -> np.ndarray:
+def _to_ndarray(data: MatLike) -> NumpyArray:
     """
     Convert any ``MatLike`` object into a numerical NumPy array.
 
@@ -128,7 +146,7 @@ def _validate_dims(dims: str, ndim: int) -> str:
     return normalized
 
 
-def _to_uint8(array: np.ndarray, value_range: tuple[float, float]) -> np.ndarray:
+def _to_uint8(array: NumpyArray, value_range: tuple[float, float]) -> UInt8NumpyArray:
     """
     Rescale an array from ``value_range`` into the canonical ``[0, 255]`` uint8 range.
 
@@ -143,13 +161,13 @@ def _to_uint8(array: np.ndarray, value_range: tuple[float, float]) -> np.ndarray
             f"'value_range' must be an increasing (low, high) tuple, got {value_range}."
         )
     if value_range == _DEFAULT_VALUE_RANGE and array.dtype == np.uint8:
-        return array
+        return cast(UInt8NumpyArray, array)
     scaled = (array.astype(np.float64) - low) / (high - low) * 255.0
     scaled = np.clip(scaled, 0.0, 255.0)
     return scaled.astype(np.uint8)
 
 
-def _split_into_images(array: np.ndarray, dims: str) -> list[np.ndarray]:
+def _split_into_images(array: UInt8NumpyArray, dims: str) -> list[UInt8NumpyArray]:
     """
     Reorder an array into ``(B, H, W[, C])`` and split it along the batch axis.
 
@@ -170,7 +188,7 @@ def _to_image_list(
     images: MatLike,
     dims: str = "HWC",
     value_range: tuple[float, float] = (0.0, 255.0),
-) -> list[np.ndarray]:
+) -> list[UInt8NumpyArray]:
     """
     Normalize a single ``MatLike`` object into canonical per-image arrays.
 

--- a/pyvisim/typing/_typing.py
+++ b/pyvisim/typing/_typing.py
@@ -74,7 +74,7 @@ SimilarityFunc = Callable[[FloatNumpyArray, FloatNumpyArray], FloatNumpyArray]
 
 #: Anything that can be turned into a numerical NumPy array: a NumPy array, a
 #: PyTorch tensor, or any array-like object (e.g. nested lists of numbers).
-MatLike = np.ndarray | torch.Tensor | npt.ArrayLike
+MatLike = torch.Tensor | npt.ArrayLike
 
 #: A single image or a collection of images. Either one ``MatLike`` object
 #: (optionally carrying a batch axis) or an iterable of ``MatLike`` images.

--- a/pyvisim/typing/_typing.py
+++ b/pyvisim/typing/_typing.py
@@ -1,0 +1,197 @@
+"""
+Typing utilities and image-normalization helpers for pyvisim.
+
+This module defines :data:`MatLike`, the permissive image type accepted across
+the public API, and the helpers that turn any ``MatLike`` input into the
+canonical NumPy layout the rest of the library works with.
+
+Canonical layout
+=================
+Every image is normalized to a ``uint8`` NumPy array of shape ``(H, W, C)``
+(or ``(H, W)`` for single-channel images) with values in the ``[0, 255]``
+range. SIFT/RootSIFT (OpenCV) and :class:`DeepConvFeature` (torchvision
+transforms) both expect this representation, so normalizing once keeps the
+downstream code unified.
+
+Dimension labels (``dims``)
+===========================
+The ``dims`` string tells the helpers how to read the axes of an input array.
+Each character names one axis, in the exact order the axes appear:
+
+- ``"B"``: batch axis (number of images).
+- ``"H"``: height axis (number of rows).
+- ``"W"``: width axis (number of columns).
+- ``"C"``: channel axis (e.g. RGB color channels).
+
+Common examples:
+
+- ``"HWC"``: a single image laid out height x width x channels
+  (the classic NumPy/OpenCV layout). This is the default.
+- ``"CHW"``: a single image laid out channels x height x width
+  (the classic PyTorch layout).
+- ``"BHWC"``: a batch of images, batch x height x width x channels.
+- ``"BCHW"``: a batch of images, batch x channels x height x width
+  (the PyTorch batched layout).
+- ``"HWCB"``: height x width x channels x batch.
+
+``"B"`` and ``"C"`` are optional; ``"H"`` and ``"W"`` are mandatory. When the
+``dims`` string contains a batch axis, the input is split into the individual
+images it contains.
+
+Value range (``value_range``)
+=============================
+``value_range`` is the ``(low, high)`` range the *input* values live in. It
+defaults to ``(0.0, 255.0)`` (standard 8-bit images). If a different range is
+provided, e.g. ``(0.0, 1.0)`` for normalized float tensors, the values are
+rescaled into the canonical ``[0, 255]`` range.
+"""
+
+from collections.abc import Iterable
+
+import numpy as np
+import numpy.typing as npt
+import torch
+
+from .._errors import InvalidImageError
+
+#: Anything that can be turned into a numerical NumPy array: a NumPy array, a
+#: PyTorch tensor, or any array-like object (e.g. nested lists of numbers).
+MatLike = np.ndarray | torch.Tensor | npt.ArrayLike
+
+#: A single image or a collection of images. Either one ``MatLike`` object
+#: (optionally carrying a batch axis) or an iterable of ``MatLike`` images.
+ImageInput = MatLike | Iterable[MatLike]
+
+_VALID_DIM_CHARS = frozenset("BHWC")
+_CANONICAL_AXIS_ORDER = "BHWC"
+_DEFAULT_VALUE_RANGE: tuple[float, float] = (0.0, 255.0)
+
+
+def _to_ndarray(data: MatLike) -> np.ndarray:
+    """
+    Convert any ``MatLike`` object into a numerical NumPy array.
+
+    :param data: A NumPy array, a PyTorch tensor, or any array-like object.
+    :return: The data as a NumPy array.
+    :raises InvalidImageError: If the data cannot be turned into a numeric array.
+    """
+    if isinstance(data, torch.Tensor):
+        return data.detach().cpu().numpy()
+    if isinstance(data, np.ndarray):
+        array = data
+    else:
+        try:
+            array = np.asarray(data)
+        except (ValueError, TypeError) as exc:
+            raise InvalidImageError(
+                f"Could not convert object of type {type(data).__name__!r} "
+                "to a NumPy array."
+            ) from exc
+    if not np.issubdtype(array.dtype, np.number) and not np.issubdtype(
+        array.dtype, np.bool_
+    ):
+        raise InvalidImageError(
+            f"Expected a numeric array, but got an array with dtype {array.dtype!r}."
+        )
+    return array
+
+
+def _validate_dims(dims: str, ndim: int) -> str:
+    """
+    Validate a ``dims`` string against the number of array dimensions.
+
+    :param dims: Axis-label string, one character per axis (case-insensitive).
+        ``"H"`` = height, ``"W"`` = width, ``"C"`` = channels, ``"B"`` = batch.
+        For example, ``"HWC"`` is height × width × channels (the default).
+    :param ndim: Number of dimensions of the array the labels describe.
+    :return: The normalized (upper-cased) ``dims`` string.
+    :raises ValueError: If the string is malformed or inconsistent with ``ndim``.
+    """
+    normalized = dims.upper()
+    if len(normalized) != ndim:
+        raise ValueError(
+            f"'dims' string {dims!r} describes {len(normalized)} axis/axes, "
+            f"but the array has {ndim} dimension(s)."
+        )
+    if len(set(normalized)) != len(normalized):
+        raise ValueError(f"'dims' string {dims!r} contains duplicate axis labels.")
+    invalid = set(normalized) - _VALID_DIM_CHARS
+    if invalid:
+        raise ValueError(
+            f"'dims' string {dims!r} contains invalid axis labels {sorted(invalid)}. "
+            "Only 'B' (batch), 'H' (height), 'W' (width) and 'C' (channels) are allowed."
+        )
+    if "H" not in normalized or "W" not in normalized:
+        raise ValueError(
+            f"'dims' string {dims!r} must contain both 'H' (height) and 'W' (width)."
+        )
+    return normalized
+
+
+def _to_uint8(array: np.ndarray, value_range: tuple[float, float]) -> np.ndarray:
+    """
+    Rescale an array from ``value_range`` into the canonical ``[0, 255]`` uint8 range.
+
+    :param array: Numeric array to rescale.
+    :param value_range: The ``(low, high)`` range the input values live in.
+    :return: A ``uint8`` array with values clipped to ``[0, 255]``.
+    :raises ValueError: If ``value_range`` is not strictly increasing.
+    """
+    low, high = value_range
+    if high <= low:
+        raise ValueError(
+            f"'value_range' must be an increasing (low, high) tuple, got {value_range}."
+        )
+    if value_range == _DEFAULT_VALUE_RANGE and array.dtype == np.uint8:
+        return array
+    scaled = (array.astype(np.float64) - low) / (high - low) * 255.0
+    scaled = np.clip(scaled, 0.0, 255.0)
+    return scaled.astype(np.uint8)
+
+
+def _split_into_images(array: np.ndarray, dims: str) -> list[np.ndarray]:
+    """
+    Reorder an array into ``(B, H, W[, C])`` and split it along the batch axis.
+
+    :param array: Array whose axes are described by ``dims``.
+    :param dims: Validated, normalized ``dims`` string.
+    :return: A list of contiguous per-image arrays of shape ``(H, W[, C])``.
+    """
+    target = "".join(axis for axis in _CANONICAL_AXIS_ORDER if axis in dims)
+    reordered = np.transpose(array, [dims.index(axis) for axis in target])
+    if "B" not in dims:
+        reordered = reordered[np.newaxis, ...]
+    return [
+        np.ascontiguousarray(reordered[index]) for index in range(reordered.shape[0])
+    ]
+
+
+def _to_image_list(
+    images: MatLike,
+    dims: str = "HWC",
+    value_range: tuple[float, float] = (0.0, 255.0),
+) -> list[np.ndarray]:
+    """
+    Normalize a single ``MatLike`` object into canonical per-image arrays.
+
+    The input may carry a batch axis (when ``dims`` contains ``"B"``), in which
+    case it is split into the individual images it holds. See the module
+    docstring for the meaning of ``dims`` and ``value_range``.
+
+    :param images: A NumPy array, a PyTorch tensor, or any array-like object.
+    :param dims: Axis-label string, one character per array axis in order:
+        ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
+        (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
+        width × channels (NumPy/OpenCV single-image layout, **default**);
+        ``"CHW"`` is channels × height × width (PyTorch single-image layout);
+        ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
+    :param value_range: The ``(low, high)`` range the input values live in
+        (default ``(0.0, 255.0)``).
+    :return: A list of ``uint8`` images of shape ``(H, W[, C])`` in ``[0, 255]``.
+    :raises InvalidImageError: If the input cannot be converted to a numeric array.
+    :raises ValueError: If ``dims`` or ``value_range`` are invalid.
+    """
+    array = _to_ndarray(images)
+    normalized_dims = _validate_dims(dims, array.ndim)
+    array = _to_uint8(array, value_range)
+    return _split_into_images(array, normalized_dims)

--- a/tests/encoders/test_fisher_vector.py
+++ b/tests/encoders/test_fisher_vector.py
@@ -99,10 +99,12 @@ def test_fisher_encode_batch_shape(
     assert fisher_no_pca.encode(batch).shape == (2, FISHER_DIM_NO_PCA)
 
 
-def test_fisher_encode_rejects_tensor(fisher_no_pca: FisherVectorEncoder) -> None:
-    """Encoding a torch tensor raises ``RuntimeError``."""
-    with pytest.raises(RuntimeError, match="Torch images are not supported"):
-        fisher_no_pca.encode(torch.zeros(3, 64, 64))
+def test_fisher_encode_accepts_tensor(
+    fisher_no_pca: FisherVectorEncoder, checkerboard_image: ImageObj
+) -> None:
+    """A grayscale torch tensor image is accepted and encodes like its array."""
+    tensor = torch.from_numpy(checkerboard_image.array)
+    assert fisher_no_pca.encode([tensor]).shape == (1, FISHER_DIM_NO_PCA)
 
 
 def test_fisher_encode_no_descriptors(

--- a/tests/encoders/test_pipeline.py
+++ b/tests/encoders/test_pipeline.py
@@ -88,10 +88,12 @@ def test_pipeline_encode_batch(
     assert pipeline.encode(batch).shape == (2, PIPELINE_DIM)
 
 
-def test_pipeline_encode_rejects_tensor(pipeline: Pipeline) -> None:
-    """Encoding a torch tensor raises ``RuntimeError``."""
-    with pytest.raises(RuntimeError, match="Torch images are not supported"):
-        pipeline.encode(torch.zeros(3, 64, 64))
+def test_pipeline_encode_accepts_tensor(
+    pipeline: Pipeline, checkerboard_image: ImageObj
+) -> None:
+    """A grayscale torch tensor image is accepted and encodes like its array."""
+    tensor = torch.from_numpy(checkerboard_image.array)
+    assert pipeline.encode([tensor]).shape == (1, PIPELINE_DIM)
 
 
 def test_pipeline_similarity_score_shape(

--- a/tests/encoders/test_vlad.py
+++ b/tests/encoders/test_vlad.py
@@ -135,10 +135,12 @@ def test_vlad_encode_no_descriptors_raises(
         vlad_no_pca.encode([solid_image.array])
 
 
-def test_vlad_encode_rejects_tensor(vlad_no_pca: VLADEncoder) -> None:
-    """Encoding a torch tensor raises ``RuntimeError``."""
-    with pytest.raises(RuntimeError, match="Torch images are not supported"):
-        vlad_no_pca.encode(torch.zeros(3, 64, 64))
+def test_vlad_encode_accepts_tensor(
+    vlad_no_pca: VLADEncoder, checkerboard_image: ImageObj
+) -> None:
+    """A grayscale torch tensor image is accepted and encodes like its array."""
+    tensor = torch.from_numpy(checkerboard_image.array)
+    assert vlad_no_pca.encode([tensor]).shape == (1, VLAD_DIM_NO_PCA)
 
 
 def test_vlad_predict_before_learn_raises(checkerboard_image: ImageObj) -> None:

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -66,10 +66,13 @@ def test_sift_tiny_returns_empty(tiny_image: ImageObj) -> None:
     assert SIFT()(tiny_image.array).shape == (0, 128)
 
 
-def test_sift_rejects_tensor() -> None:
-    """Passing a torch tensor raises ``TypeError``."""
-    with pytest.raises(TypeError):
-        SIFT()(torch.zeros(3, 64, 64))
+def test_sift_accepts_tensor(checkerboard_image: ImageObj) -> None:
+    """A grayscale torch tensor is accepted and yields the ``(N, 128)`` contract."""
+    tensor = torch.from_numpy(checkerboard_image.array)
+    out = SIFT()(tensor)
+    assert out.ndim == 2
+    assert out.shape[1] == 128
+    assert out.shape[0] > 0
 
 
 def test_sift_repr() -> None:
@@ -129,10 +132,13 @@ def test_rootsift_low_contrast_returns_empty() -> None:
     assert RootSIFT()(image).shape == (0, 128)
 
 
-def test_rootsift_rejects_tensor() -> None:
-    """Passing a torch tensor raises ``TypeError``."""
-    with pytest.raises(TypeError):
-        RootSIFT()(torch.zeros(3, 64, 64))
+def test_rootsift_accepts_tensor(checkerboard_image: ImageObj) -> None:
+    """A grayscale torch tensor is accepted and yields the ``(N, 128)`` contract."""
+    tensor = torch.from_numpy(checkerboard_image.array)
+    out = RootSIFT()(tensor)
+    assert out.ndim == 2
+    assert out.shape[1] == 128
+    assert out.shape[0] > 0
 
 
 def test_rootsift_repr() -> None:
@@ -201,11 +207,11 @@ def test_lambda_none_returns_empty(checkerboard_image: ImageObj) -> None:
     assert extractor(checkerboard_image.array).shape == (0, 4)
 
 
-def test_lambda_rejects_tensor() -> None:
-    """Passing a torch tensor raises ``TypeError`` before the function runs."""
+def test_lambda_accepts_tensor() -> None:
+    """A torch tensor is normalized and passed through to the function."""
     extractor = Lambda(lambda image: np.ones((5, 4), np.float32), output_dim=4)
-    with pytest.raises(TypeError):
-        extractor(torch.zeros(3, 8, 8))
+    out = extractor(torch.zeros(8, 8))
+    assert out.shape == (5, 4)
 
 
 # DeepConvFeature
@@ -285,11 +291,11 @@ def test_deepconv_non_module_model_raises() -> None:
         DeepConvFeature(model="not a module", device="cpu")  # type: ignore[arg-type]
 
 
-def test_deepconv_rejects_tensor() -> None:
-    """Passing a torch tensor raises ``TypeError``."""
+def test_deepconv_accepts_tensor() -> None:
+    """A ``CHW`` torch tensor is accepted when its layout is described via ``dims``."""
     extractor = DeepConvFeature(_tiny_conv_model(), device="cpu")
-    with pytest.raises(TypeError):
-        extractor(torch.zeros(3, 64, 64))
+    out = extractor(torch.zeros(3, 64, 64), dims="CHW")
+    assert out.ndim == 2
 
 
 @pytest.mark.slow


### PR DESCRIPTION
### Related Issues

- closes #

### Proposed Changes:

This PR adds first-class PyTorch tensor support across pyvisim's public API by introducing a new `pyvisim.typing` module and threading `dims`/`value_range` parameters through every feature extractor and encoder.

Previously, passing a `torch.Tensor` anywhere raised `RuntimeError("Torch images are not supported yet.")`. Now the entire stack accepts NumPy arrays, PyTorch tensors, or anything `numpy.asarray` can handle. The caller describes the axis layout with a `dims` string (e.g. `"HWC"`, `"BCHW"`) and the value range with `value_range`, and the library normalizes the input to a canonical `uint8 (H, W, C)` NumPy array once before handing it downstream.

Key pieces:

- **`pyvisim/typing/_typing.py`** — new module with `MatLike` and `ImageInput` type aliases plus four private helpers: `_to_ndarray` (torch → NumPy), `_validate_dims` (validates/normalizes the axis string), `_to_uint8` (rescales float inputs into `[0, 255]`), and `_split_into_images` (reorders axes and splits on the batch dimension).
- **`pyvisim/encoders/utils.py`** — new `iter_images()` generator that accepts a single `MatLike` or an iterable of them, yielding one canonical image at a time. It replaces the ad-hoc `isinstance(images, torch.Tensor)` guards that were scattered across every encoder's `encode()`.
- **Feature extractors** (`SIFT`, `RootSIFT`, `Lambda`, `DeepConvFeature`) — each `__call__` now accepts `MatLike` and `dims`/`value_range`, normalizing to a single image at the top via the new `_to_single_image` helper.
- **Encoders** (`VLADEncoder`, `FisherVectorEncoder`, `Pipeline`) — `encode()` and `similarity_score()` updated to accept `ImageInput` + `dims`/`value_range`, delegating to `iter_images()`.
- **Abstract base classes and `Encoder` Protocol in `eval.py`** — updated signatures to match.

### How did you test it?

- Ran `make test-types` (mypy strict) and `make fmt` — both pass.
- Manually verified that a `torch.Tensor` in `"CHW"` layout and a float tensor in `[0, 1]` with `value_range=(0.0, 1.0)` are correctly normalized to `uint8 (H, W, C)` before feature extraction.

### Notes for the reviewer

The `dims`/`value_range` parameters are purely keyword-only to avoid breaking existing callers who pass positional image arguments. The default `dims="HWC"` and `value_range=(0.0, 255.0)` preserve the old NumPy-only behavior exactly.

`_to_image_list` is exported from `pyvisim.typing` (as a semi-public internal) because `pyvisim/features/_features.py` imports it directly. If we'd rather keep it fully private, I can duplicate the call inside `_to_single_image` or move it — happy to discuss.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md).
- [ ] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `feat:` — no breaking changes.
- [x] I have documented my code.
- [x] When applicable: I have reviewed the AI-generated code sections, according to [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#using-ai-to-contribute).
- [x] I have run [pre-commit hooks](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#set-up-developer-environment) and fixed any issue.