### PR TITLE
Feat: add unittests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,61 @@ jobs:
 
       - name: Check format
         run: uv run --group fmt ruff format --check .
+
+  # 3: pytest unit tests with coverage
+  tests:
+    name: "Unit tests (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          allow-prereleases: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install dependencies
+        run: uv sync --group test
+
+      - name: Run pytest with coverage
+        run: uv run --group test pytest -m "not slow"
+
+  # 4: slow integration tests
+  slow-tests:
+    name: "Slow tests (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          allow-prereleases: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install dependencies
+        run: uv sync --group test
+
+      - name: Run slow tests
+        run: uv run --group test pytest -m "slow"

--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,9 @@ pyvisim/one_time_use.py
 doc/
 res/
 
+# Generated test debug images (written by tests/conftest.py)
+tests/debug/
+
 # Files to keep in the ignored folders
 !res/images/
 !pyvisim/res/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,16 @@
-.PHONY: test-types
+.PHONY: test-types test-unit fmt
 
 # Strict mypy type-checking
 test-types:
 	uv run --group types mypy pyvisim/
 
+# Unit tests with a terminal coverage report (skips slow, weight-downloading tests)
+test-unit:
+	uv run --group test pytest -m "not slow"
+
+# Test slow tests
+test-slow:
+	uv run --group test pytest -m slow
 # Formatting with ruff
 fmt:
 	uv run --group fmt ruff check --fix .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,3 +124,18 @@ indent-style = "space"
 [tool.codespell]
 ignore-words-list = "Commun"
 skip = "./examples"  # jupyter notebooks
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# Always emit a coverage report at the end of every run, locally and in CI.
+addopts = "--cov=pyvisim --cov-report=term-missing"
+markers = [
+  "slow: tests that download model weights or data (deselect with '-m \"not slow\"')",
+]
+
+[tool.coverage.run]
+source = ["pyvisim"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,10 @@ dead-code = [
 fmt = [
   "ruff",
 ]
+test = [
+    "pytest",
+    "pytest-cov",
+]
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/clustering/test_base_clustering.py
+++ b/tests/clustering/test_base_clustering.py
@@ -1,0 +1,27 @@
+"""Tests for the clustering base classes, exercised via concrete models."""
+
+from __future__ import annotations
+
+import pytest
+from sklearn.exceptions import NotFittedError
+
+from pyvisim.clustering import PCA, ClusteringModelBase, KMeans
+
+
+def test_clustering_base_is_abstract() -> None:
+    """``ClusteringModelBase`` cannot be instantiated directly (it is abstract)."""
+    with pytest.raises(TypeError):
+        ClusteringModelBase()  # type: ignore[abstract]
+
+
+def test_repr_contains_model() -> None:
+    """The shared ``__repr__`` names the concrete class and its model."""
+    text = repr(KMeans(8))
+    assert "KMeans(" in text
+    assert "model=" in text
+
+
+def test_check_is_fitted_message() -> None:
+    """The shared fitted check raises a message mentioning the unfitted state."""
+    with pytest.raises(NotFittedError, match="is not fitted yet"):
+        _ = PCA(4).n_components

--- a/tests/clustering/test_gmm.py
+++ b/tests/clustering/test_gmm.py
@@ -1,0 +1,112 @@
+"""Tests for :class:`pyvisim.clustering.GaussianMixtureModel`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from sklearn.exceptions import NotFittedError
+from sklearn.mixture import GaussianMixture
+
+from pyvisim.clustering import GaussianMixtureModel
+
+
+@pytest.fixture
+def fitted_gmm() -> GaussianMixtureModel:
+    """A ``GaussianMixtureModel(4)`` fitted on deterministic ``(300, 5)`` data.
+
+    :returns: a fitted :class:`pyvisim.clustering.GaussianMixtureModel`.
+    """
+    rng = np.random.default_rng(0)
+    model = GaussianMixtureModel(4, random_state=0)
+    model.fit(rng.random((300, 5)))
+    return model
+
+
+def test_gmm_default_covariance_is_diag() -> None:
+    """The underlying sklearn model is forced to ``covariance_type='diag'``."""
+    assert GaussianMixtureModel(4)._model.covariance_type == "diag"
+
+
+def test_gmm_non_diag_covariance_raises() -> None:
+    """Requesting a non-diagonal covariance type raises ``ValueError``."""
+    with pytest.raises(ValueError, match=r"only supports covariance_type='diag'"):
+        GaussianMixtureModel(4, covariance_type="full")
+
+
+def test_gmm_n_clusters_equals_n_components() -> None:
+    """``n_clusters`` mirrors ``n_components`` and works before fitting."""
+    assert GaussianMixtureModel(6).n_clusters == 6
+
+
+def test_gmm_weights_before_fit_raises() -> None:
+    """Accessing ``weights`` before fitting raises ``NotFittedError``."""
+    with pytest.raises(NotFittedError):
+        _ = GaussianMixtureModel(4).weights
+
+
+def test_gmm_means_before_fit_raises() -> None:
+    """Accessing ``means`` before fitting raises ``NotFittedError``."""
+    with pytest.raises(NotFittedError):
+        _ = GaussianMixtureModel(4).means
+
+
+def test_gmm_covariances_before_fit_raises() -> None:
+    """Accessing ``covariances`` before fitting raises ``NotFittedError``."""
+    with pytest.raises(NotFittedError):
+        _ = GaussianMixtureModel(4).covariances
+
+
+def test_gmm_predict_proba_before_fit_raises() -> None:
+    """Calling ``predict_proba`` before fitting raises ``NotFittedError``."""
+    rng = np.random.default_rng(0)
+    with pytest.raises(NotFittedError):
+        GaussianMixtureModel(4).predict_proba(rng.random((10, 5)))
+
+
+def test_gmm_weights_shape_and_sum(fitted_gmm: GaussianMixtureModel) -> None:
+    """Mixture weights have shape ``(k,)`` and sum to one."""
+    assert fitted_gmm.weights.shape == (4,)
+    assert fitted_gmm.weights.sum() == pytest.approx(1.0)
+
+
+def test_gmm_means_shape(fitted_gmm: GaussianMixtureModel) -> None:
+    """Component means have shape ``(k, D)``."""
+    assert fitted_gmm.means.shape == (4, 5)
+
+
+def test_gmm_covariances_shape(fitted_gmm: GaussianMixtureModel) -> None:
+    """Diagonal covariances have shape ``(k, D)``."""
+    assert fitted_gmm.covariances.shape == (4, 5)
+
+
+def test_gmm_predict_proba_shape_and_rows_sum(
+    fitted_gmm: GaussianMixtureModel,
+) -> None:
+    """``predict_proba`` returns ``(N, k)`` posteriors whose rows sum to one."""
+    rng = np.random.default_rng(1)
+    proba = fitted_gmm.predict_proba(rng.random((30, 5)))
+    assert proba.shape == (30, 4)
+    assert np.allclose(proba.sum(axis=1), 1.0)
+
+
+def test_gmm_from_sklearn_non_diag_raises() -> None:
+    """``_from_sklearn`` rejects a non-diagonal sklearn mixture."""
+    with pytest.raises(ValueError):
+        GaussianMixtureModel._from_sklearn(GaussianMixture(covariance_type="full"))
+
+
+def test_gmm_from_sklearn_diag_ok() -> None:
+    """``_from_sklearn`` adopts a fitted diagonal sklearn mixture."""
+    rng = np.random.default_rng(0)
+    sklearn_model = GaussianMixture(
+        n_components=3, covariance_type="diag", random_state=0
+    )
+    sklearn_model.fit(rng.random((60, 5)))
+    adopted = GaussianMixtureModel._from_sklearn(sklearn_model)
+    assert adopted.n_clusters == 3
+
+
+def test_gmm_from_sklearn_wrong_type_raises() -> None:
+    """``_from_sklearn`` rejects objects that are not the expected estimator."""
+    with pytest.raises(TypeError):
+        GaussianMixtureModel._from_sklearn(object())

--- a/tests/clustering/test_kmeans.py
+++ b/tests/clustering/test_kmeans.py
@@ -1,0 +1,86 @@
+"""Tests for :class:`pyvisim.clustering.KMeans`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from sklearn.exceptions import NotFittedError
+
+from pyvisim.clustering import KMeans
+
+
+@pytest.fixture
+def fitted_kmeans() -> KMeans:
+    """A reproducible ``KMeans(8)`` fitted on ``(200, 5)`` data.
+
+    :returns: a fitted :class:`pyvisim.clustering.KMeans` instance.
+    """
+    rng = np.random.default_rng(0)
+    model = KMeans(8, random_state=0, n_init=3)
+    model.fit(rng.random((200, 5)))
+    return model
+
+
+def test_kmeans_n_clusters_before_fit() -> None:
+    """``n_clusters`` reflects the constructor argument without fitting."""
+    assert KMeans(8).n_clusters == 8
+
+
+def test_kmeans_is_fitted_false_before_fit() -> None:
+    """A freshly built KMeans reports ``is_fitted is False``."""
+    assert KMeans(8).is_fitted is False
+
+
+def test_kmeans_cluster_centers_before_fit_raises() -> None:
+    """Accessing ``cluster_centers`` before fitting raises ``NotFittedError``."""
+    with pytest.raises(NotFittedError):
+        _ = KMeans(8).cluster_centers
+
+
+def test_kmeans_predict_before_fit_raises() -> None:
+    """Calling ``predict`` before fitting raises ``NotFittedError``."""
+    rng = np.random.default_rng(0)
+    with pytest.raises(NotFittedError):
+        KMeans(8).predict(rng.random((10, 5)))
+
+
+def test_kmeans_cluster_centers_shape(fitted_kmeans: KMeans) -> None:
+    """Cluster centers have shape ``(n_clusters, n_features)``."""
+    assert fitted_kmeans.cluster_centers.shape == (8, 5)
+
+
+def test_kmeans_n_features_in_after_fit(fitted_kmeans: KMeans) -> None:
+    """A fitted KMeans reports the number of input features it saw."""
+    assert fitted_kmeans.n_features_in == 5
+
+
+def test_kmeans_predict_labels_in_range(fitted_kmeans: KMeans) -> None:
+    """``predict`` returns one label per sample, each in ``[0, n_clusters)``."""
+    rng = np.random.default_rng(1)
+    labels = fitted_kmeans.predict(rng.random((50, 5)))
+    assert labels.shape == (50,)
+    assert labels.min() >= 0
+    assert labels.max() < 8
+
+
+def test_kmeans_predict_is_ndarray(fitted_kmeans: KMeans) -> None:
+    """``predict`` returns a NumPy array."""
+    rng = np.random.default_rng(1)
+    assert isinstance(fitted_kmeans.predict(rng.random((50, 5))), np.ndarray)
+
+
+def test_kmeans_random_state_reproducible() -> None:
+    """A fixed ``random_state`` yields identical cluster centers."""
+    rng = np.random.default_rng(0)
+    data = rng.random((200, 5))
+    first = KMeans(8, random_state=0, n_init=3)
+    second = KMeans(8, random_state=0, n_init=3)
+    first.fit(data)
+    second.fit(data)
+    assert np.allclose(first.cluster_centers, second.cluster_centers)
+
+
+def test_kmeans_from_sklearn_wrong_type_raises() -> None:
+    """``_from_sklearn`` rejects objects that are not the expected estimator."""
+    with pytest.raises(TypeError):
+        KMeans._from_sklearn(object())

--- a/tests/clustering/test_pca.py
+++ b/tests/clustering/test_pca.py
@@ -1,0 +1,101 @@
+"""Tests for :class:`pyvisim.clustering.PCA`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from sklearn.decomposition import PCA as SklearnPCA
+from sklearn.exceptions import NotFittedError
+
+from pyvisim.clustering import PCA
+
+
+@pytest.fixture
+def fitted_pca() -> PCA:
+    """A ``PCA(4)`` fitted on deterministic ``(100, 10)`` data.
+
+    :returns: a fitted :class:`pyvisim.clustering.PCA` instance.
+    """
+    rng = np.random.default_rng(0)
+    model = PCA(4)
+    model.fit(rng.random((100, 10)))
+    return model
+
+
+def test_pca_is_fitted_false_before_fit() -> None:
+    """A freshly built PCA reports ``is_fitted is False``."""
+    assert PCA(4).is_fitted is False
+
+
+def test_pca_n_components_before_fit_raises() -> None:
+    """Accessing ``n_components`` before fitting raises ``NotFittedError``."""
+    with pytest.raises(NotFittedError):
+        _ = PCA(4).n_components
+
+
+def test_pca_n_features_in_before_fit_raises() -> None:
+    """Accessing ``n_features_in`` before fitting raises ``NotFittedError``."""
+    with pytest.raises(NotFittedError):
+        _ = PCA(4).n_features_in
+
+
+def test_pca_transform_before_fit_raises() -> None:
+    """Calling ``transform`` before fitting raises ``NotFittedError``."""
+    rng = np.random.default_rng(0)
+    with pytest.raises(NotFittedError):
+        PCA(4).transform(rng.random((20, 10)))
+
+
+def test_pca_fit_sets_is_fitted(fitted_pca: PCA) -> None:
+    """Fitting flips ``is_fitted`` to ``True``."""
+    assert fitted_pca.is_fitted is True
+
+
+def test_pca_n_components_after_fit(fitted_pca: PCA) -> None:
+    """A fitted PCA exposes its requested ``n_components``."""
+    assert fitted_pca.n_components == 4
+
+
+def test_pca_n_features_in_after_fit(fitted_pca: PCA) -> None:
+    """A fitted PCA reports the number of input features it saw."""
+    assert fitted_pca.n_features_in == 10
+
+
+def test_pca_transform_shape(fitted_pca: PCA) -> None:
+    """``transform`` reduces the feature dimension to ``n_components``."""
+    rng = np.random.default_rng(1)
+    out = fitted_pca.transform(rng.random((20, 10)))
+    assert out.shape == (20, 4)
+
+
+def test_pca_transform_is_ndarray(fitted_pca: PCA) -> None:
+    """``transform`` returns a NumPy array."""
+    rng = np.random.default_rng(1)
+    out = fitted_pca.transform(rng.random((20, 10)))
+    assert isinstance(out, np.ndarray)
+
+
+def test_pca_forwards_params() -> None:
+    """Extra params (``whiten``) are forwarded to the underlying sklearn PCA."""
+    rng = np.random.default_rng(0)
+    data = rng.random((200, 10))
+    model = PCA(4, whiten=True, random_state=0)
+    model.fit(data)
+    out = model.transform(data)
+    # Whitening makes each projected component have ~unit variance.
+    assert np.allclose(out.var(axis=0), 1.0, atol=0.05)
+
+
+def test_pca_from_sklearn_adopts_fitted() -> None:
+    """``_from_sklearn`` adopts an already-fitted sklearn estimator."""
+    rng = np.random.default_rng(0)
+    sklearn_model = SklearnPCA(n_components=3).fit(rng.random((50, 10)))
+    adopted = PCA._from_sklearn(sklearn_model)
+    assert adopted.is_fitted is True
+    assert adopted.n_components == 3
+
+
+def test_pca_from_sklearn_wrong_type_raises() -> None:
+    """``_from_sklearn`` rejects objects that are not the expected estimator."""
+    with pytest.raises(TypeError):
+        PCA._from_sklearn(object())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,8 @@ import numpy as np
 import pytest
 from PIL import Image
 
+from pyvisim.encoders import FisherVectorEncoder, VLADEncoder
+
 #: Directory where generated test images are dumped for manual inspection.
 DEBUG_DIR = Path(__file__).parent / "debug"
 
@@ -263,6 +265,34 @@ def checkerboard_image() -> ImageObj:
 
 
 @pytest.fixture
+def blobs_image() -> ImageObj:
+    """A field of random white rectangles on black, corner-rich and structurally distinct from a checkerboard.
+
+    Uses a seed not present in the training data so it acts as an unseen query.
+
+    :returns: an ``ImageObj`` object with the ``(256, 256)`` ``uint8`` array.
+    """
+    image = _make_blobs(size=MAIN_SIZE, seed=9999)
+    _save_debug_image(image, "blobs_image")
+    return ImageObj(array=image, path=DEBUG_DIR / "blobs_image.png")
+
+
+@pytest.fixture
+def noisy_checkerboard_image() -> ImageObj:
+    """A checkerboard image with mild Gaussian noise (std=15) applied.
+
+    Used to assert that a noisy variant of an image is more similar to its
+    clean original than to a structurally different image.
+
+    :returns: an ``ImageObj`` object with the ``(256, 256)`` ``uint8`` array.
+    """
+    base = _make_checkerboard(size=MAIN_SIZE)
+    image = _add_gaussian_noise(base, std=15.0, seed=42)
+    _save_debug_image(image, "noisy_checkerboard_image")
+    return ImageObj(array=image, path=DEBUG_DIR / "noisy_checkerboard_image.png")
+
+
+@pytest.fixture
 def horizontal_gradient_image() -> ImageObj:
     """A smooth horizontal gradient with very few sharp features.
 
@@ -326,26 +356,6 @@ def very_noisy_image_pair() -> tuple[ImageObj, ImageObj]:
 
 
 @pytest.fixture
-def extremely_noisy_image_pair() -> tuple[ImageObj, ImageObj]:
-    """Two checkerboard images with heavy, independent gaussian noise.
-
-    Both images share the same base pattern and noise standard deviation
-    (``std=90``), pushing the pattern close to indistinguishable from
-    random noise.
-
-    :returns: a tuple of two ``ImageObj`` objects with ``(256, 256)`` ``uint8``
-        arrays.
-    """
-    image_a, image_b = _make_noise_pair("extremely_noisy")
-    _save_debug_image(image_a, "extremely_noisy_image_a")
-    _save_debug_image(image_b, "extremely_noisy_image_b")
-    return (
-        ImageObj(array=image_a, path=DEBUG_DIR / "extremely_noisy_image_a.png"),
-        ImageObj(array=image_b, path=DEBUG_DIR / "extremely_noisy_image_b.png"),
-    )
-
-
-@pytest.fixture
 def identical_image_pair() -> tuple[np.ndarray, np.ndarray]:
     """Two pixel-identical checkerboard images.
 
@@ -360,75 +370,151 @@ def identical_image_pair() -> tuple[np.ndarray, np.ndarray]:
     return image, image.copy()
 
 
-@pytest.fixture
-def rotated_image_pair() -> tuple[np.ndarray, np.ndarray]:
-    """A stripe image and a 90-degree rotation of itself.
+#: Number of training images generated per category.
+CATEGORY_TRAIN_SIZE = 10
 
-    Rotating vertical stripes by 90 degrees turns them into horizontal
-    stripes, giving a meaningful (non-trivial) rotation test.
+#: PCA configurations used to parametrize the learned-encoder fixtures: one
+#: variant without PCA and one with PCA reducing descriptors to 32 dimensions.
+PCA_PARAMS = [None, {"n_components": 32, "random_state": 0}]
 
-    :returns: a tuple ``(image, rotated_image)`` of ``(256, 256)``
-        ``uint8`` arrays.
+
+def _make_blobs(size: int, seed: int, n_blobs: int = 40) -> np.ndarray:
+    """Generate a corner-rich field of random white rectangles on black.
+
+    Unlike the regular checkerboard, this produces an irregular texture, so
+    the two categories used in the behavioural tests are visually and
+    descriptively distinct while both still yielding RootSIFT descriptors.
+
+    :param size: width and height of the square image, in pixels.
+    :param seed: random seed controlling the (fixed) blob layout.
+    :param n_blobs: number of white rectangles to draw.
+    :returns: a ``(size, size)`` ``uint8`` array.
     """
-    image = _make_stripes(size=MAIN_SIZE)
-    rotated = np.rot90(image).copy()
-    _save_debug_image(image, "rotated_image_pair_original")
-    _save_debug_image(rotated, "rotated_image_pair_rotated")
-    return image, rotated
+    rng = np.random.default_rng(seed)
+    image = np.zeros((size, size), dtype=np.uint8)
+    for _ in range(n_blobs):
+        y, x = rng.integers(0, size - 30, size=2)
+        height, width = rng.integers(10, 30, size=2)
+        image[y : y + height, x : x + width] = 255
+    return image
 
 
-@pytest.fixture
-def shifted_image_pair() -> tuple[ImageObj, ImageObj]:
-    """A checkerboard image and a translated (shifted) version of itself.
+def _category_variant(base: np.ndarray, seed: int) -> np.ndarray:
+    """Create an intra-category variant via a small shift plus mild noise.
 
-    The shift is smaller than one checkerboard square, so the pattern
-    remains recognizable but no longer pixel-aligned.
+    The variation is deliberately small so that all variants of one base
+    pattern remain mutually similar, while differing enough to be non-trivial.
 
-    :returns: a tuple of two ``ImageObj`` objects with ``(256, 256)``
-        ``uint8`` arrays.
+    :param base: the category's base ``uint8`` image.
+    :param seed: random seed, fixed for reproducibility.
+    :returns: a ``uint8`` array with the same shape as ``base``.
     """
-    image = _make_checkerboard(size=MAIN_SIZE)
-    shifted = np.roll(image, shift=8, axis=1)
-    _save_debug_image(image, "shifted_image_pair_original")
-    _save_debug_image(shifted, "shifted_image_pair_shifted")
-    return (
-        ImageObj(array=image, path=DEBUG_DIR / "shifted_image_pair_original.png"),
-        ImageObj(array=shifted, path=DEBUG_DIR / "shifted_image_pair_shifted.png"),
+    rng = np.random.default_rng(seed)
+    shift_y = int(rng.integers(-5, 6))
+    shift_x = int(rng.integers(-5, 6))
+    shifted = np.roll(np.roll(base, shift_y, axis=0), shift_x, axis=1)
+    noisy = shifted.astype(np.float64) + rng.normal(0.0, 6.0, base.shape)
+    return np.clip(noisy, 0, 255).astype(np.uint8)
+
+
+#: Base pattern per category. ``checker`` is the standard checkerboard; ``blobs``
+#: is a random-rectangle field. Both are corner-rich and mutually distinct.
+_CATEGORY_BASES = {
+    "checker": _make_checkerboard(MAIN_SIZE),
+    "blobs": _make_blobs(MAIN_SIZE, seed=1234),
+}
+
+
+@pytest.fixture(scope="session")
+def category_train_images() -> dict[str, list[np.ndarray]]:
+    """Training images for the behavioural tests: 2 categories, 10 images each.
+
+    Every image is ``(256, 256)`` ``uint8``, corner-rich (so RootSIFT yields
+    descriptors) and visually distinct between categories.
+
+    :returns: a mapping ``{category_name: [image, ...]}`` with
+        :data:`CATEGORY_TRAIN_SIZE` images per category.
+    """
+    images: dict[str, list[np.ndarray]] = {}
+    for offset, (name, base) in enumerate(_CATEGORY_BASES.items()):
+        seed0 = offset * 1000
+        images[name] = [
+            _category_variant(base, seed0 + i) for i in range(CATEGORY_TRAIN_SIZE)
+        ]
+        _save_debug_image(images[name][0], f"category_train_{name}_0")
+    return images
+
+
+@pytest.fixture(scope="session")
+def category_query_images() -> dict[str, list[np.ndarray]]:
+    """Held-out query images, not present in :func:`category_train_images`.
+
+    Provides at least two new same-category images per category so that
+    same-category and different-category query pairs can be built.
+
+    :returns: a mapping ``{category_name: [image, image]}`` of held-out images.
+    """
+    images: dict[str, list[np.ndarray]] = {}
+    for offset, (name, base) in enumerate(_CATEGORY_BASES.items()):
+        seed0 = 500 + offset * 100
+        images[name] = [_category_variant(base, seed0 + i) for i in range(2)]
+        _save_debug_image(images[name][0], f"category_query_{name}_0")
+    return images
+
+
+@pytest.fixture(scope="session")
+def category_train_images_flat(
+    category_train_images: dict[str, list[np.ndarray]],
+) -> list[np.ndarray]:
+    """All training images flattened into a single list, for ``learn``.
+
+    :param category_train_images: the per-category training image fixture.
+    :returns: a flat list of every training image across all categories.
+    """
+    return [image for images in category_train_images.values() for image in images]
+
+
+@pytest.fixture(scope="session", params=PCA_PARAMS, ids=["no_pca", "pca32"])
+def learned_vlad_encoder(
+    request: pytest.FixtureRequest,
+    category_train_images_flat: list[np.ndarray],
+) -> VLADEncoder:
+    """A :class:`VLADEncoder` already learned on the training images.
+
+    Parametrized over a non-PCA and a PCA variant so dependent tests run for
+    both paths. Session-scoped to avoid re-fitting per test.
+
+    :param request: the pytest request, carrying the PCA params for this variant.
+    :param category_train_images_flat: flattened training images to learn from.
+    :returns: a fitted ``VLADEncoder`` with ``n_clusters=8``.
+    """
+    encoder = VLADEncoder(
+        n_clusters=8,
+        kmeans_params={"random_state": 0, "n_init": 3},
+        pca_params=request.param,
     )
+    encoder.learn(category_train_images_flat)
+    return encoder
 
 
-@pytest.fixture
-def different_image_pair() -> tuple[ImageObj, ImageObj]:
-    """Two clearly different patterns: a checkerboard and a stripe image.
+@pytest.fixture(scope="session", params=PCA_PARAMS, ids=["no_pca", "pca32"])
+def learned_fisher_encoder(
+    request: pytest.FixtureRequest,
+    category_train_images_flat: list[np.ndarray],
+) -> FisherVectorEncoder:
+    """A :class:`FisherVectorEncoder` already learned on the training images.
 
-    Used as a baseline for "these should NOT be considered similar".
+    Parametrized over a non-PCA and a PCA variant so dependent tests run for
+    both paths. Session-scoped to avoid re-fitting per test.
 
-    :returns: a tuple of two ``ImageObj`` objects with ``(256, 256)``
-        ``uint8`` arrays.
+    :param request: the pytest request, carrying the PCA params for this variant.
+    :param category_train_images_flat: flattened training images to learn from.
+    :returns: a fitted ``FisherVectorEncoder`` with ``n_components=8``.
     """
-    image_a = _make_checkerboard(size=MAIN_SIZE)
-    image_b = _make_stripes(size=MAIN_SIZE)
-    _save_debug_image(image_a, "different_image_pair_a")
-    _save_debug_image(image_b, "different_image_pair_b")
-    return (
-        ImageObj(array=image_a, path=DEBUG_DIR / "different_image_pair_a.png"),
-        ImageObj(array=image_b, path=DEBUG_DIR / "different_image_pair_b.png"),
+    encoder = FisherVectorEncoder(
+        n_components=8,
+        gmm_params={"random_state": 0},
+        pca_params=request.param,
     )
-
-
-@pytest.fixture
-def image_batch(
-    checkerboard_image: ImageObj,
-    horizontal_gradient_image: ImageObj,
-    stripes_image: ImageObj,
-    solid_image: ImageObj,
-) -> list[ImageObj]:
-    """A small batch of varied images for testing :class:`Pipeline` encoding.
-
-    :param checkerboard_image: fixture providing a checkerboard image.
-    :param horizontal_gradient_image: fixture providing a horizontal gradient image.
-    :param stripes_image: fixture providing a stripe image.
-    :param solid_image: fixture providing a featureless solid image.
-    :returns: a list of four ``ImageObj`` objects with ``(256, 256)`` ``uint8`` arrays.
-    """
-    return [checkerboard_image, horizontal_gradient_image, stripes_image, solid_image]
+    encoder.learn(category_train_images_flat)
+    return encoder

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,434 @@
+"""Shared pytest fixtures for pyvisim's encoder test suite."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+#: Directory where generated test images are dumped for manual inspection.
+DEBUG_DIR = Path(__file__).parent / "debug"
+
+#: Fixed side length used for most cases
+MAIN_SIZE = 256
+
+#: Gaussian noise configuration for each noise level. ``seed_a``/``seed_b``
+#: are independent seeds used to generate the two images of a pair, so the
+#: pair shares a noise *level* but not the actual noise pattern.
+NOISE_LEVELS = {
+    "noisy": {"std": 15.0, "seed_a": 101, "seed_b": 102},
+    "very_noisy": {"std": 40.0, "seed_a": 201, "seed_b": 202},
+    "extremely_noisy": {"std": 90.0, "seed_a": 301, "seed_b": 302},
+}
+
+
+@dataclass
+class ImageObj:
+    """Return object for all tests, holds the path and array of the image."""
+
+    array: np.ndarray
+    path: Path
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Reset the debug image directory before the test session starts.
+
+    Removes any leftover images from a previous run and re-creates an
+    empty ``tests/debug/`` directory, so it always reflects only the
+    most recent run.
+
+    :param config: the pytest configuration object (unused).
+    """
+    if DEBUG_DIR.exists():
+        shutil.rmtree(DEBUG_DIR)
+    DEBUG_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _save_debug_image(image: np.ndarray, name: str) -> None:
+    """Write a generated test image to ``tests/debug/`` as a PNG file.
+
+    :param image: image array to save, either ``(H, W)`` grayscale or
+        ``(H, W, 3)`` RGB, with dtype ``uint8``.
+    :param name: file name (without extension) to save the image under.
+    """
+    Image.fromarray(image).save(DEBUG_DIR / f"{name}.png")
+
+
+def _make_solid_image(size: int, value: int) -> np.ndarray:
+    """Generate a uniform, single-color grayscale image.
+
+    :param size: width and height of the square image, in pixels.
+    :param value: pixel intensity to fill the image with (0-255).
+    :returns: a ``(size, size)`` ``uint8`` array filled with ``value``.
+    """
+    return np.full((size, size), value, dtype=np.uint8)
+
+
+def _make_checkerboard(size: int, square: int = 16) -> np.ndarray:
+    """Generate a black-and-white checkerboard pattern.
+
+    :param size: width and height of the square image, in pixels.
+    :param square: size of each checkerboard square, in pixels.
+    :returns: a ``(size, size)`` ``uint8`` array with values 0 or 255.
+    """
+    rows, cols = np.indices((size, size)) // square
+    pattern = (rows + cols) % 2
+    return (pattern * 255).astype(np.uint8)
+
+
+def _make_horizontal_gradient(size: int) -> np.ndarray:
+    """Generate a smooth horizontal grayscale gradient.
+
+    :param size: width and height of the square image, in pixels.
+    :returns: a ``(size, size)`` ``uint8`` array, darkest on the left and
+        brightest on the right.
+    """
+    row = np.linspace(0, 255, size, dtype=np.uint8)
+    return np.tile(row, (size, 1))
+
+
+def _make_stripes(size: int, stripe_width: int = 16) -> np.ndarray:
+    """Generate alternating black-and-white vertical stripes.
+
+    :param size: width and height of the square image, in pixels.
+    :param stripe_width: width of each stripe, in pixels.
+    :returns: a ``(size, size)`` ``uint8`` array with values 0 or 255.
+    """
+    _, cols = np.indices((size, size))
+    pattern = (cols // stripe_width) % 2
+    return (pattern * 255).astype(np.uint8)
+
+
+def _add_gaussian_noise(image: np.ndarray, std: float, seed: int) -> np.ndarray:
+    """Add reproducible gaussian noise to an image.
+
+    :param image: the base ``uint8`` image to add noise to.
+    :param std: standard deviation of the gaussian noise.
+    :param seed: random seed, fixed for reproducibility across test runs.
+    :returns: a ``uint8`` array with the same shape as ``image``, with
+        noise added and values clipped to the valid ``[0, 255]`` range.
+    """
+    rng = np.random.default_rng(seed)
+    noisy = image.astype(np.float64) + rng.normal(0.0, std, image.shape)
+    return np.clip(noisy, 0, 255).astype(np.uint8)
+
+
+def _make_noise_pair(level: str) -> tuple[np.ndarray, np.ndarray]:
+    """Build a pair of independently-noised images at a given noise level.
+
+    Both images share the same checkerboard base pattern, so they differ
+    *only* in their (independently sampled) noise. This makes them useful
+    for testing that two images with similar noise levels score as more
+    similar than two images with different noise levels.
+
+    :param level: one of the keys of :data:`NOISE_LEVELS`.
+    :returns: a tuple ``(image_a, image_b)`` of ``(256, 256)`` ``uint8``
+        arrays.
+    """
+    config = NOISE_LEVELS[level]
+    base = _make_checkerboard(size=MAIN_SIZE)
+    image_a = _add_gaussian_noise(base, std=config["std"], seed=config["seed_a"])
+    image_b = _add_gaussian_noise(base, std=config["std"], seed=config["seed_b"])
+    return image_a, image_b
+
+
+@pytest.fixture
+def tiny_image() -> ImageObj:
+    """An 8x8 checkerboard image, smaller than typical descriptor patches.
+
+    :returns: an ``ImageObj`` object with the ``(8, 8)`` ``uint8`` array.
+    """
+    image = _make_checkerboard(size=8, square=2)
+    _save_debug_image(image, "tiny_image")
+    return ImageObj(array=image, path=DEBUG_DIR / "tiny_image.png")
+
+
+@pytest.fixture
+def small_image() -> ImageObj:
+    """A 32x32 checkerboard image.
+
+    :returns: an ``ImageObj`` object with the ``(32, 32)`` ``uint8`` array.
+    """
+    image = _make_checkerboard(size=32, square=4)
+    _save_debug_image(image, "small_image")
+    return ImageObj(array=image, path=DEBUG_DIR / "small_image.png")
+
+
+@pytest.fixture
+def large_image() -> ImageObj:
+    """A 512x512 checkerboard image.
+
+    :returns: an ``ImageObj`` object with the ``(512, 512)`` ``uint8`` array.
+    """
+    image = _make_checkerboard(size=512, square=32)
+    _save_debug_image(image, "large_image")
+    return ImageObj(array=image, path=DEBUG_DIR / "large_image.png")
+
+
+@pytest.fixture
+def non_square_image() -> ImageObj:
+    """A 128x256 (height x width) checkerboard image.
+
+    Used to confirm that the encoder does not silently assume square
+    inputs.
+
+    :returns: an ``ImageObj`` object with the ``(128, 256)`` ``uint8`` array.
+    """
+    rows, cols = np.indices((128, 256)) // 16
+    pattern = ((rows + cols) % 2 * 255).astype(np.uint8)
+    _save_debug_image(pattern, "non_square_image")
+    return ImageObj(array=pattern, path=DEBUG_DIR / "non_square_image.png")
+
+
+@pytest.fixture
+def grayscale_image() -> ImageObj:
+    """A single-channel (grayscale) checkerboard image at the edge-case size.
+
+    :returns: an ``ImageObj`` object with the ``(256, 256)`` ``uint8`` array.
+    """
+    image = _make_checkerboard(size=MAIN_SIZE)
+    _save_debug_image(image, "grayscale_image")
+    return ImageObj(array=image, path=DEBUG_DIR / "grayscale_image.png")
+
+
+@pytest.fixture()
+def black_image() -> ImageObj:
+    """A completely black image (all RGB channels zero).
+
+    :returns: an ``ImageObj`` object with the ``(256, 256)`` ``uint8`` array
+        filled with zeros.
+    """
+    image = _make_solid_image(size=MAIN_SIZE, value=0)
+    _save_debug_image(image, "black_image")
+    return ImageObj(array=image, path=DEBUG_DIR / "black_image.png")
+
+
+@pytest.fixture()
+def white_image() -> ImageObj:
+    """A completely white image (all RGB channels 255).
+
+    :returns: an ``ImageObj`` object with the ``(256, 256)`` ``uint8`` array
+        filled with 255.
+    """
+    image = _make_solid_image(size=MAIN_SIZE, value=255)
+    _save_debug_image(image, "white_image")
+    return ImageObj(array=image, path=DEBUG_DIR / "white_image.png")
+
+
+@pytest.fixture
+def rgb_image() -> ImageObj:
+    """A 3-channel (RGB) checkerboard image at the edge-case size.
+
+    The same pattern as :func:`grayscale_image`, replicated across all
+    three color channels.
+
+    :returns: an ``ImageObj`` object with the ``(256, 256, 3)`` ``uint8`` array.
+    """
+    gray = _make_checkerboard(size=MAIN_SIZE)
+    rgb = np.stack([gray, gray, gray], axis=-1)
+    _save_debug_image(rgb, "rgb_image")
+    return ImageObj(array=rgb, path=DEBUG_DIR / "rgb_image.png")
+
+
+@pytest.fixture
+def solid_image() -> ImageObj:
+    """A uniform mid-gray image with no texture at all.
+
+    Most keypoint detectors will find zero descriptors in this image --
+    use it to verify that the encoder handles the "no descriptors found"
+    case gracefully (e.g. by raising a clear error or returning a zero
+    vector), rather than crashing.
+
+    :returns: an ``ImageObj`` object with the ``(256, 256)`` ``uint8`` array
+        filled with the value 128.
+    """
+    image = _make_solid_image(size=MAIN_SIZE, value=128)
+    _save_debug_image(image, "solid_image")
+    return ImageObj(array=image, path=DEBUG_DIR / "solid_image.png")
+
+
+@pytest.fixture
+def checkerboard_image() -> ImageObj:
+    """A black-and-white checkerboard image with strong, predictable corners.
+
+    :returns: an ``ImageObj`` object with the ``(256, 256)`` ``uint8`` array.
+    """
+    image = _make_checkerboard(size=MAIN_SIZE)
+    _save_debug_image(image, "checkerboard_image")
+    return ImageObj(array=image, path=DEBUG_DIR / "checkerboard_image.png")
+
+
+@pytest.fixture
+def horizontal_gradient_image() -> ImageObj:
+    """A smooth horizontal gradient with very few sharp features.
+
+    :returns: an ``ImageObj`` object with the ``(256, 256)`` ``uint8`` array.
+    """
+    image = _make_horizontal_gradient(size=MAIN_SIZE)
+    _save_debug_image(image, "horizontal_gradient_image")
+    return ImageObj(array=image, path=DEBUG_DIR / "horizontal_gradient_image.png")
+
+
+@pytest.fixture
+def stripes_image() -> ImageObj:
+    """A repeating vertical stripe pattern.
+
+    :returns: an ``ImageObj`` object with the ``(256, 256)`` ``uint8`` array.
+    """
+    image = _make_stripes(size=MAIN_SIZE)
+    _save_debug_image(image, "stripes_image")
+    return ImageObj(array=image, path=DEBUG_DIR / "stripes_image.png")
+
+
+# Similarity test pairs (fixed 256x256 size)
+
+
+@pytest.fixture
+def noisy_image_pair() -> tuple[ImageObj, ImageObj]:
+    """Two checkerboard images with mild, independent gaussian noise.
+
+    Both images share the same base pattern and noise standard deviation
+    (``std=15``), so an encoder should consider them highly similar.
+
+    :returns: a tuple of two ``ImageObj`` objects with ``(256, 256)`` ``uint8``
+        arrays.
+    """
+    image_a, image_b = _make_noise_pair("noisy")
+    _save_debug_image(image_a, "noisy_image_a")
+    _save_debug_image(image_b, "noisy_image_b")
+    return (
+        ImageObj(array=image_a, path=DEBUG_DIR / "noisy_image_a.png"),
+        ImageObj(array=image_b, path=DEBUG_DIR / "noisy_image_b.png"),
+    )
+
+
+@pytest.fixture
+def very_noisy_image_pair() -> tuple[ImageObj, ImageObj]:
+    """Two checkerboard images with moderate, independent gaussian noise.
+
+    Both images share the same base pattern and noise standard deviation
+    (``std=40``).
+
+    :returns: a tuple of two ``ImageObj`` objects with ``(256, 256)`` ``uint8``
+        arrays.
+    """
+    image_a, image_b = _make_noise_pair("very_noisy")
+    _save_debug_image(image_a, "very_noisy_image_a")
+    _save_debug_image(image_b, "very_noisy_image_b")
+    return (
+        ImageObj(array=image_a, path=DEBUG_DIR / "very_noisy_image_a.png"),
+        ImageObj(array=image_b, path=DEBUG_DIR / "very_noisy_image_b.png"),
+    )
+
+
+@pytest.fixture
+def extremely_noisy_image_pair() -> tuple[ImageObj, ImageObj]:
+    """Two checkerboard images with heavy, independent gaussian noise.
+
+    Both images share the same base pattern and noise standard deviation
+    (``std=90``), pushing the pattern close to indistinguishable from
+    random noise.
+
+    :returns: a tuple of two ``ImageObj`` objects with ``(256, 256)`` ``uint8``
+        arrays.
+    """
+    image_a, image_b = _make_noise_pair("extremely_noisy")
+    _save_debug_image(image_a, "extremely_noisy_image_a")
+    _save_debug_image(image_b, "extremely_noisy_image_b")
+    return (
+        ImageObj(array=image_a, path=DEBUG_DIR / "extremely_noisy_image_a.png"),
+        ImageObj(array=image_b, path=DEBUG_DIR / "extremely_noisy_image_b.png"),
+    )
+
+
+@pytest.fixture
+def identical_image_pair() -> tuple[np.ndarray, np.ndarray]:
+    """Two pixel-identical checkerboard images.
+
+    Used to verify that encoding the same image twice yields (near)
+    perfect similarity.
+
+    :returns: a tuple ``(image_a, image_b)`` of ``(256, 256)`` ``uint8``
+        arrays with identical contents.
+    """
+    image = _make_checkerboard(size=MAIN_SIZE)
+    _save_debug_image(image, "identical_image_pair")
+    return image, image.copy()
+
+
+@pytest.fixture
+def rotated_image_pair() -> tuple[np.ndarray, np.ndarray]:
+    """A stripe image and a 90-degree rotation of itself.
+
+    Rotating vertical stripes by 90 degrees turns them into horizontal
+    stripes, giving a meaningful (non-trivial) rotation test.
+
+    :returns: a tuple ``(image, rotated_image)`` of ``(256, 256)``
+        ``uint8`` arrays.
+    """
+    image = _make_stripes(size=MAIN_SIZE)
+    rotated = np.rot90(image).copy()
+    _save_debug_image(image, "rotated_image_pair_original")
+    _save_debug_image(rotated, "rotated_image_pair_rotated")
+    return image, rotated
+
+
+@pytest.fixture
+def shifted_image_pair() -> tuple[ImageObj, ImageObj]:
+    """A checkerboard image and a translated (shifted) version of itself.
+
+    The shift is smaller than one checkerboard square, so the pattern
+    remains recognizable but no longer pixel-aligned.
+
+    :returns: a tuple of two ``ImageObj`` objects with ``(256, 256)``
+        ``uint8`` arrays.
+    """
+    image = _make_checkerboard(size=MAIN_SIZE)
+    shifted = np.roll(image, shift=8, axis=1)
+    _save_debug_image(image, "shifted_image_pair_original")
+    _save_debug_image(shifted, "shifted_image_pair_shifted")
+    return (
+        ImageObj(array=image, path=DEBUG_DIR / "shifted_image_pair_original.png"),
+        ImageObj(array=shifted, path=DEBUG_DIR / "shifted_image_pair_shifted.png"),
+    )
+
+
+@pytest.fixture
+def different_image_pair() -> tuple[ImageObj, ImageObj]:
+    """Two clearly different patterns: a checkerboard and a stripe image.
+
+    Used as a baseline for "these should NOT be considered similar".
+
+    :returns: a tuple of two ``ImageObj`` objects with ``(256, 256)``
+        ``uint8`` arrays.
+    """
+    image_a = _make_checkerboard(size=MAIN_SIZE)
+    image_b = _make_stripes(size=MAIN_SIZE)
+    _save_debug_image(image_a, "different_image_pair_a")
+    _save_debug_image(image_b, "different_image_pair_b")
+    return (
+        ImageObj(array=image_a, path=DEBUG_DIR / "different_image_pair_a.png"),
+        ImageObj(array=image_b, path=DEBUG_DIR / "different_image_pair_b.png"),
+    )
+
+
+@pytest.fixture
+def image_batch(
+    checkerboard_image: ImageObj,
+    horizontal_gradient_image: ImageObj,
+    stripes_image: ImageObj,
+    solid_image: ImageObj,
+) -> list[ImageObj]:
+    """A small batch of varied images for testing :class:`Pipeline` encoding.
+
+    :param checkerboard_image: fixture providing a checkerboard image.
+    :param horizontal_gradient_image: fixture providing a horizontal gradient image.
+    :param stripes_image: fixture providing a stripe image.
+    :param solid_image: fixture providing a featureless solid image.
+    :returns: a list of four ``ImageObj`` objects with ``(256, 256)`` ``uint8`` arrays.
+    """
+    return [checkerboard_image, horizontal_gradient_image, stripes_image, solid_image]

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1,0 +1,392 @@
+"""Tests for :mod:`pyvisim.datasets.datasets`.
+
+All network and filesystem boundaries are mocked; the suite never downloads or
+reads the real Oxford-102 Flowers data. Symbols are patched where they are
+*used*, i.e. as attributes of ``pyvisim.datasets.datasets``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from collections.abc import Callable, Iterator
+from typing import Any
+from unittest import mock
+
+import numpy as np
+import pytest
+from torchvision import transforms
+
+from pyvisim.datasets import OxfordFlowerDataset
+from pyvisim.datasets import datasets as ds
+from pyvisim.datasets.datasets import (
+    NUM_TEST_IMG,
+    NUM_TRAIN_IMG,
+    NUM_VAL_IMG,
+    OXFORD_NUM_IMAGES,
+)
+
+#: Five fake image file names returned by a mocked ``os.listdir``.
+_FAKE_JPGS = [f"image_{i:05d}.jpg" for i in range(1, 6)]
+
+
+def _fake_loadmat(path: str, *args: Any, **kwargs: Any) -> dict[str, np.ndarray]:
+    """A small, internally consistent fake of ``scipy.io.loadmat`` for 5 images.
+
+    The setid arrays follow the dataset's deliberate train/test swap: ``tstid``
+    becomes the train split and ``trnid`` becomes the test split.
+
+    :param path: the ``.mat`` file path being loaded.
+    :returns: the labels or setid dictionary, chosen by file name.
+    """
+    if str(path).endswith("labels.mat"):
+        return {"labels": np.array([[1, 1, 2, 2, 3]])}
+    return {
+        "tstid": np.array([[1, 2]]),  # -> train (swapped)
+        "valid": np.array([[3]]),  # -> validation
+        "trnid": np.array([[4, 5]]),  # -> test (swapped)
+    }
+
+
+def _good_loadmat(path: str, *args: Any, **kwargs: Any) -> dict[str, np.ndarray]:
+    """A fake ``loadmat`` whose lengths match the real dataset (integrity check).
+
+    :param path: the ``.mat`` file path being loaded.
+    :returns: full-length labels or setid arrays.
+    """
+    if str(path).endswith("labels.mat"):
+        return {"labels": np.ones((1, OXFORD_NUM_IMAGES), dtype=int)}
+    return {
+        "tstid": np.arange(NUM_TEST_IMG).reshape(1, -1),
+        "valid": np.arange(NUM_VAL_IMG).reshape(1, -1),
+        "trnid": np.arange(NUM_TRAIN_IMG).reshape(1, -1),
+    }
+
+
+@contextlib.contextmanager
+def _construction_io(
+    *,
+    downloaded: bool = True,
+    integrity: bool = True,
+    loadmat: Callable[..., dict[str, np.ndarray]] = _fake_loadmat,
+    listdir: list[str] | None = None,
+) -> Iterator[mock.MagicMock]:
+    """Patch the IO boundaries used while constructing an ``OxfordFlowerDataset``.
+
+    :param downloaded: value returned by the mocked ``_data_downloaded``.
+    :param integrity: value returned by the mocked ``_check_data_integrity``.
+    :param loadmat: side effect for the mocked ``scipy.io.loadmat``.
+    :param listdir: return value for the mocked ``os.listdir``.
+    :yields: the mock standing in for ``download_oxford_flowers_data``.
+    """
+    listing = _FAKE_JPGS if listdir is None else listdir
+    with (
+        mock.patch.object(ds, "_data_downloaded", return_value=downloaded),
+        mock.patch.object(ds, "_check_data_integrity", return_value=integrity),
+        mock.patch.object(ds, "download_oxford_flowers_data") as download_mock,
+        mock.patch.object(ds.scipy.io, "loadmat", side_effect=loadmat),
+        mock.patch.object(ds.os, "listdir", return_value=listing),
+    ):
+        yield download_mock
+
+
+# §4.1 _data_downloaded
+
+
+def test_data_downloaded_true() -> None:
+    """Both the root dir and the label file present means the data is downloaded."""
+    with (
+        mock.patch.object(ds.os.path, "isdir", return_value=True),
+        mock.patch.object(ds.os.path, "isfile", return_value=True),
+    ):
+        assert ds._data_downloaded() is True
+
+
+def test_data_downloaded_missing_root() -> None:
+    """A missing root directory means the data is not downloaded."""
+    with (
+        mock.patch.object(ds.os.path, "isdir", return_value=False),
+        mock.patch.object(ds.os.path, "isfile", return_value=True),
+    ):
+        assert ds._data_downloaded() is False
+
+
+def test_data_downloaded_missing_label_file() -> None:
+    """A missing label file means the data is not downloaded."""
+    with (
+        mock.patch.object(ds.os.path, "isdir", return_value=True),
+        mock.patch.object(ds.os.path, "isfile", return_value=False),
+    ):
+        assert ds._data_downloaded() is False
+
+
+# §4.2 _check_data_integrity
+
+
+def test_integrity_all_good() -> None:
+    """Correct label count, setid lengths and image count pass the integrity check."""
+    all_jpgs = [f"image_{i:05d}.jpg" for i in range(1, OXFORD_NUM_IMAGES + 1)]
+    with (
+        mock.patch.object(ds.os.path, "isfile", return_value=True),
+        mock.patch.object(ds.os.path, "isdir", return_value=True),
+        mock.patch.object(ds.scipy.io, "loadmat", side_effect=_good_loadmat),
+        mock.patch.object(ds.os, "listdir", return_value=all_jpgs),
+    ):
+        assert ds._check_data_integrity() is True
+
+
+def test_integrity_missing_label_file() -> None:
+    """A missing label file fails the integrity check."""
+    with mock.patch.object(ds.os.path, "isfile", return_value=False):
+        assert ds._check_data_integrity() is False
+
+
+def test_integrity_wrong_label_count() -> None:
+    """A wrong number of labels fails the integrity check."""
+
+    def bad_labels(path: str, *args: Any, **kwargs: Any) -> dict[str, np.ndarray]:
+        if str(path).endswith("labels.mat"):
+            return {"labels": np.ones((1, 10), dtype=int)}
+        return _good_loadmat(path)
+
+    all_jpgs = [f"image_{i:05d}.jpg" for i in range(1, OXFORD_NUM_IMAGES + 1)]
+    with (
+        mock.patch.object(ds.os.path, "isfile", return_value=True),
+        mock.patch.object(ds.os.path, "isdir", return_value=True),
+        mock.patch.object(ds.scipy.io, "loadmat", side_effect=bad_labels),
+        mock.patch.object(ds.os, "listdir", return_value=all_jpgs),
+    ):
+        assert ds._check_data_integrity() is False
+
+
+def test_integrity_wrong_setid_lengths() -> None:
+    """Wrong setid split lengths fail the integrity check."""
+
+    def bad_setid(path: str, *args: Any, **kwargs: Any) -> dict[str, np.ndarray]:
+        if str(path).endswith("labels.mat"):
+            return {"labels": np.ones((1, OXFORD_NUM_IMAGES), dtype=int)}
+        return {
+            "tstid": np.array([[1]]),
+            "valid": np.array([[1, 2]]),
+            "trnid": np.array([[1, 2, 3]]),
+        }
+
+    all_jpgs = [f"image_{i:05d}.jpg" for i in range(1, OXFORD_NUM_IMAGES + 1)]
+    with (
+        mock.patch.object(ds.os.path, "isfile", return_value=True),
+        mock.patch.object(ds.os.path, "isdir", return_value=True),
+        mock.patch.object(ds.scipy.io, "loadmat", side_effect=bad_setid),
+        mock.patch.object(ds.os, "listdir", return_value=all_jpgs),
+    ):
+        assert ds._check_data_integrity() is False
+
+
+def test_integrity_wrong_image_count() -> None:
+    """A wrong number of image files fails the integrity check."""
+    with (
+        mock.patch.object(ds.os.path, "isfile", return_value=True),
+        mock.patch.object(ds.os.path, "isdir", return_value=True),
+        mock.patch.object(ds.scipy.io, "loadmat", side_effect=_good_loadmat),
+        mock.patch.object(ds.os, "listdir", return_value=_FAKE_JPGS),
+    ):
+        assert ds._check_data_integrity() is False
+
+
+def test_integrity_loadmat_raises() -> None:
+    """An error while reading the ``.mat`` files is caught and returns ``False``."""
+    all_jpgs = [f"image_{i:05d}.jpg" for i in range(1, OXFORD_NUM_IMAGES + 1)]
+    with (
+        mock.patch.object(ds.os.path, "isfile", return_value=True),
+        mock.patch.object(ds.os.path, "isdir", return_value=True),
+        mock.patch.object(ds.scipy.io, "loadmat", side_effect=Exception("boom")),
+        mock.patch.object(ds.os, "listdir", return_value=all_jpgs),
+    ):
+        assert ds._check_data_integrity() is False
+
+
+# ---------------------------------------------------------------------------
+# §4.3 download_oxford_flowers_data
+# ---------------------------------------------------------------------------
+
+
+def test_download_spawns_three_processes() -> None:
+    """One process is spawned per file (images/labels/setid), started and joined."""
+    with (
+        mock.patch.object(ds.os, "makedirs"),
+        mock.patch.object(ds, "Process") as process_cls,
+    ):
+        ds.download_oxford_flowers_data()
+    assert process_cls.call_count == 3
+    assert process_cls.return_value.start.call_count == 3
+    assert process_cls.return_value.join.call_count == 3
+
+
+def test_download_makes_root_dir() -> None:
+    """The dataset root directory is created with ``exist_ok=True``."""
+    with (
+        mock.patch.object(ds.os, "makedirs") as makedirs_mock,
+        mock.patch.object(ds, "Process"),
+    ):
+        ds.download_oxford_flowers_data()
+    makedirs_mock.assert_any_call(ds._DATASET_ROOT, exist_ok=True)
+
+
+# §4.4 _download_and_process_file / _download_file_with_progress
+
+
+def test_process_zip_dispatch() -> None:
+    """A ``.zip`` destination is unzipped and then removed."""
+    with (
+        mock.patch.object(ds, "_download_file_with_progress"),
+        mock.patch.object(ds, "_extract_zip") as extract_zip,
+        mock.patch.object(ds, "_extract_tar") as extract_tar,
+        mock.patch.object(ds.os, "remove") as remove,
+    ):
+        ds._download_and_process_file("http://x", "a.zip", "/tmp/extract")
+    assert extract_zip.call_count == 1
+    assert extract_tar.call_count == 0
+    remove.assert_called_once_with("a.zip")
+
+
+def test_process_tgz_dispatch() -> None:
+    """A ``.tgz`` destination is untarred and then removed."""
+    with (
+        mock.patch.object(ds, "_download_file_with_progress"),
+        mock.patch.object(ds, "_extract_zip") as extract_zip,
+        mock.patch.object(ds, "_extract_tar") as extract_tar,
+        mock.patch.object(ds.os, "remove") as remove,
+    ):
+        ds._download_and_process_file("http://x", "a.tgz", "/tmp/extract")
+    assert extract_tar.call_count == 1
+    assert extract_zip.call_count == 0
+    remove.assert_called_once_with("a.tgz")
+
+
+def test_process_other_no_extract() -> None:
+    """A non-archive destination is neither extracted nor removed."""
+    with (
+        mock.patch.object(ds, "_download_file_with_progress"),
+        mock.patch.object(ds, "_extract_zip") as extract_zip,
+        mock.patch.object(ds, "_extract_tar") as extract_tar,
+        mock.patch.object(ds.os, "remove") as remove,
+    ):
+        ds._download_and_process_file("http://x", "a.mat", "/tmp/extract")
+    assert extract_zip.call_count == 0
+    assert extract_tar.call_count == 0
+    assert remove.call_count == 0
+
+
+def test_download_writes_content() -> None:
+    """Streamed response chunks are written to the destination file handle."""
+
+    class _FakeResponse:
+        headers = {"content-length": "8"}
+
+        def iter_content(self, chunk_size: int = 1) -> list[bytes]:
+            return [b"abcd", b"efgh"]
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def __enter__(self) -> _FakeResponse:
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            return None
+
+    open_mock = mock.mock_open()
+    with (
+        mock.patch.object(ds.requests, "get", return_value=_FakeResponse()),
+        mock.patch("builtins.open", open_mock),
+    ):
+        ds._download_file_with_progress("http://x", "/tmp/f.bin")
+    handle = open_mock()
+    handle.write.assert_any_call(b"abcd")
+    handle.write.assert_any_call(b"efgh")
+
+
+# §4.5 OxfordFlowerDataset
+
+
+def test_transform_not_none_raises() -> None:
+    """Supplying a transform raises ``NotImplementedError`` (not yet supported)."""
+    with _construction_io():
+        with pytest.raises(
+            NotImplementedError, match="Transformations are not yet supported"
+        ):
+            OxfordFlowerDataset(transform=transforms.Compose([]))
+
+
+def test_duplicate_purposes_raises() -> None:
+    """Duplicate purposes raise ``ValueError``."""
+    with _construction_io():
+        with pytest.raises(ValueError, match="Duplicate purposes"):
+            OxfordFlowerDataset(purpose=["train", "train"])
+
+
+def test_unknown_purpose_raises() -> None:
+    """An unknown purpose raises ``ValueError``."""
+    with _construction_io():
+        with pytest.raises(ValueError, match="Unknown purpose: foo"):
+            OxfordFlowerDataset(purpose="foo")
+
+
+def test_triggers_download_when_missing() -> None:
+    """A missing/invalid dataset triggers a download exactly once."""
+    with _construction_io(downloaded=False, integrity=False) as download_mock:
+        OxfordFlowerDataset(purpose="train")
+    assert download_mock.call_count == 1
+
+
+def test_no_download_when_present() -> None:
+    """A present and valid dataset does not trigger a download."""
+    with _construction_io() as download_mock:
+        OxfordFlowerDataset(purpose="train")
+    assert download_mock.call_count == 0
+
+
+def test_len_matches_filtered_train() -> None:
+    """``len`` reflects the filtered train split (the swapped ``tstid`` = ``[1, 2]``)."""
+    with _construction_io():
+        dataset = OxfordFlowerDataset(purpose="train")
+    assert len(dataset) == 2
+
+
+def test_filter_by_purpose_selects_correct_paths() -> None:
+    """The train split selects the images and labels for ids 1 and 2."""
+    with _construction_io():
+        dataset = OxfordFlowerDataset(purpose="train")
+    basenames = [os.path.basename(path) for path in dataset.image_paths]
+    assert basenames == ["image_00001.jpg", "image_00002.jpg"]
+    assert list(dataset.labels) == [1, 1]
+
+
+def test_combined_purposes_dedup() -> None:
+    """Combining train and validation yields the deduplicated id set {1, 2, 3}."""
+    with _construction_io():
+        dataset = OxfordFlowerDataset(purpose=["train", "validation"])
+    assert len(dataset) == 3
+
+
+def test_getitem_returns_triple() -> None:
+    """Indexing returns an ``(image, label, path)`` triple."""
+    with _construction_io():
+        dataset = OxfordFlowerDataset(purpose="train")
+        with mock.patch.object(
+            ds, "read_image_rgb", return_value=np.zeros((256, 256, 3), np.uint8)
+        ):
+            image, label, path = dataset[0]
+    assert image.shape == (256, 256, 3)
+    assert label == 1
+    assert isinstance(path, str)
+
+
+def test_getitem_calls_read_image_rgb() -> None:
+    """Indexing reads the image at the corresponding path via ``read_image_rgb``."""
+    with _construction_io():
+        dataset = OxfordFlowerDataset(purpose="train")
+        with mock.patch.object(
+            ds, "read_image_rgb", return_value=np.zeros((256, 256, 3), np.uint8)
+        ) as read_mock:
+            dataset[0]
+    assert read_mock.call_args[0][0] == dataset.image_paths[0]

--- a/tests/encoders/test_base_encoder.py
+++ b/tests/encoders/test_base_encoder.py
@@ -1,0 +1,267 @@
+"""Tests for the encoder base class and its similarity-function helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import joblib
+import numpy as np
+import pytest
+from PIL import Image
+from sklearn.exceptions import NotFittedError
+from sklearn.metrics.pairwise import cosine_similarity
+
+from pyvisim.clustering import PCA
+from pyvisim.encoders import FisherVectorEncoder, VLADEncoder
+from pyvisim.encoders._base_encoder import (
+    ImageEncoderBase,
+    _make_fallback_func,
+    check_desired_output,
+)
+from pyvisim.features import Lambda, RootSIFT
+
+if TYPE_CHECKING:
+    from tests.conftest import ImageObj
+
+
+# ---------------------------------------------------------------------------
+# §3.1 check_desired_output / _make_fallback_func
+# ---------------------------------------------------------------------------
+
+
+def _list_returning_func(vecs1: np.ndarray, vecs2: np.ndarray) -> list[list[int]]:
+    """A similarity function that wrongly returns a Python list."""
+    return [[1, 2]]
+
+
+def _wrong_shape_func(vecs1: np.ndarray, vecs2: np.ndarray) -> np.ndarray:
+    """A similarity function that returns an array of the wrong shape."""
+    return np.zeros((3, 3))
+
+
+def _raising_func(vecs1: np.ndarray, vecs2: np.ndarray) -> np.ndarray:
+    """A similarity function that always raises."""
+    raise RuntimeError("boom")
+
+
+def _scalar_cosine(vecs1: np.ndarray, vecs2: np.ndarray) -> float:
+    """Cosine similarity of two single-row inputs reduced to a scalar.
+
+    The row-wise fallback assigns the result to a scalar cell, so the wrapped
+    function must return a scalar rather than a ``(1, 1)`` array.
+    """
+    return float(cosine_similarity(vecs1, vecs2)[0, 0])
+
+
+def test_cdo_valid_returns_same_func() -> None:
+    """A valid similarity function is returned unchanged."""
+    rng = np.random.default_rng(0)
+    vecs = rng.random((10, 10))
+    assert check_desired_output(cosine_similarity, vecs, vecs) is cosine_similarity
+
+
+def test_cdo_raising_func_falls_back() -> None:
+    """A raising similarity function is replaced by a fallback, with a warning."""
+    rng = np.random.default_rng(0)
+    vecs = rng.random((10, 10))
+    with pytest.warns(UserWarning, match="threw an error"):
+        result = check_desired_output(_raising_func, vecs, vecs)
+    assert result is not _raising_func
+
+
+def test_cdo_non_ndarray_falls_back() -> None:
+    """A function returning a non-array is replaced by a fallback, with a warning."""
+    rng = np.random.default_rng(0)
+    vecs = rng.random((10, 10))
+    with pytest.warns(UserWarning, match="Expected a NumPy array"):
+        result = check_desired_output(_list_returning_func, vecs, vecs)
+    assert result is not _list_returning_func
+
+
+def test_cdo_wrong_shape_falls_back() -> None:
+    """A function returning the wrong shape is replaced by a fallback, with a warning."""
+    rng = np.random.default_rng(0)
+    vecs = rng.random((10, 10))
+    with pytest.warns(UserWarning, match="not the expected"):
+        result = check_desired_output(_wrong_shape_func, vecs, vecs)
+    assert result is not _wrong_shape_func
+
+
+def test_fallback_loops_rowwise() -> None:
+    """The fallback wrapper builds an ``(N1, N2)`` float32 matrix row-wise."""
+    fallback = _make_fallback_func(_scalar_cosine)
+    rng = np.random.default_rng(0)
+    out = fallback(rng.random((4, 5)), rng.random((3, 5)))
+    assert out.shape == (4, 3)
+    assert out.dtype == np.float32
+
+
+# §3.2 ImageEncoderBase shared behaviour (exercised via VLADEncoder)
+
+
+class _NoModelEncoder(ImageEncoderBase):
+    """Minimal concrete encoder used to test the "no clustering model" path."""
+
+    def encode(self, images: Iterable[np.ndarray], flatten: bool = True) -> np.ndarray:
+        """Unused stub; ``learn`` fails before encoding is ever reached."""
+        raise NotImplementedError
+
+
+@pytest.fixture(scope="module")
+def learned_vlad(category_train_images_flat: list[np.ndarray]) -> VLADEncoder:
+    """A ``VLADEncoder(n_clusters=8)`` learned once for this module.
+
+    :param category_train_images_flat: flattened training images to learn from.
+    :returns: a fitted ``VLADEncoder``.
+    """
+    encoder = VLADEncoder(n_clusters=8, kmeans_params={"random_state": 0, "n_init": 3})
+    encoder.learn(category_train_images_flat)
+    return encoder
+
+
+def test_default_feature_extractor_is_rootsift() -> None:
+    """Encoders default to the RootSIFT feature extractor."""
+    assert isinstance(VLADEncoder(n_clusters=8).feature_extractor, RootSIFT)
+
+
+def test_feature_extractor_setter_type_check() -> None:
+    """Assigning a non-extractor to ``feature_extractor`` raises ``TypeError``."""
+    encoder = VLADEncoder(n_clusters=8)
+    with pytest.raises(TypeError):
+        encoder.feature_extractor = "x"  # type: ignore[assignment]
+
+
+def test_pca_setter_type_check() -> None:
+    """Assigning a non-PCA object to ``pca`` raises ``ValueError``."""
+    encoder = VLADEncoder(n_clusters=8)
+    with pytest.raises(
+        ValueError, match="must be an instance of pyvisim.clustering.PCA"
+    ):
+        encoder.pca = object()  # type: ignore[assignment]
+
+
+def test_learn_without_clustering_model_raises(
+    category_train_images_flat: list[np.ndarray],
+) -> None:
+    """Learning with no clustering model raises ``RuntimeError``."""
+    encoder = _NoModelEncoder(clustering_model=None)
+    with pytest.raises(RuntimeError, match="no clustering model"):
+        encoder.learn(category_train_images_flat)
+
+
+def test_learn_bad_dim_reduction_factor_zero(
+    category_train_images_flat: list[np.ndarray],
+) -> None:
+    """A zero ``dim_reduction_factor`` raises ``ValueError``."""
+    encoder = VLADEncoder(n_clusters=8, kmeans_params={"random_state": 0, "n_init": 3})
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        encoder.learn(category_train_images_flat, dim_reduction_factor=0)
+
+
+def test_learn_bad_dim_reduction_factor_negative(
+    category_train_images_flat: list[np.ndarray],
+) -> None:
+    """A negative ``dim_reduction_factor`` raises ``ValueError``."""
+    encoder = VLADEncoder(n_clusters=8, kmeans_params={"random_state": 0, "n_init": 3})
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        encoder.learn(category_train_images_flat, dim_reduction_factor=-2)
+
+
+def test_learn_with_dim_reduction_factor_builds_pca(
+    category_train_images_flat: list[np.ndarray],
+) -> None:
+    """A ``dim_reduction_factor`` builds and fits a PCA halving the dimension."""
+    encoder = VLADEncoder(n_clusters=8, kmeans_params={"random_state": 0, "n_init": 3})
+    encoder.learn(category_train_images_flat, dim_reduction_factor=2)
+    assert isinstance(encoder.pca, PCA)
+    assert encoder.pca.is_fitted is True
+    assert encoder.pca.n_components == 64  # RootSIFT dim 128 // 2
+
+
+def test_feature_extractor_pca_dim_mismatch_raises(
+    category_train_images_flat: list[np.ndarray],
+) -> None:
+    """Assigning an extractor whose output dim mismatches the fitted PCA raises."""
+    encoder = VLADEncoder(n_clusters=8, kmeans_params={"random_state": 0, "n_init": 3})
+    encoder.learn(category_train_images_flat, dim_reduction_factor=2)  # PCA in=128
+    with pytest.raises(RuntimeError):
+        encoder.feature_extractor = Lambda(
+            lambda image: np.ones((5, 64), np.float32), output_dim=64
+        )
+
+
+def test_save_unfitted_raises(tmp_path: Path) -> None:
+    """Saving an unfitted encoder raises ``NotFittedError``."""
+    encoder = VLADEncoder(n_clusters=8)
+    with pytest.raises(NotFittedError, match="not fitted"):
+        encoder.save_to_disk(tmp_path / "m")
+
+
+def test_save_appends_suffix(learned_vlad: VLADEncoder, tmp_path: Path) -> None:
+    """Saving appends the ``.encoder`` suffix and writes the file."""
+    path = learned_vlad.save_to_disk(tmp_path / "model")
+    assert str(path).endswith(".encoder")
+    assert path.exists()
+
+
+def test_save_keeps_existing_suffix(learned_vlad: VLADEncoder, tmp_path: Path) -> None:
+    """Saving with an existing ``.encoder`` suffix does not double it."""
+    path = learned_vlad.save_to_disk(tmp_path / "m.encoder")
+    assert path.name == "m.encoder"
+
+
+def test_load_roundtrip_same_encoding(
+    learned_vlad: VLADEncoder, tmp_path: Path, checkerboard_image: ImageObj
+) -> None:
+    """A saved-and-reloaded encoder produces the same encoding."""
+    path = learned_vlad.save_to_disk(tmp_path / "model")
+    loaded = VLADEncoder.load_from_disk(path)
+    assert np.allclose(
+        loaded.encode([checkerboard_image.array]),
+        learned_vlad.encode([checkerboard_image.array]),
+    )
+
+
+def test_load_invalid_file_raises(tmp_path: Path) -> None:
+    """Loading a file that is not a valid encoder raises ``ValueError``."""
+    bad = tmp_path / "bad.encoder"
+    joblib.dump({"foo": 1}, bad)
+    with pytest.raises(ValueError, match="not a valid .encoder file"):
+        VLADEncoder.load_from_disk(bad)
+
+
+def test_load_wrong_class_raises(learned_vlad: VLADEncoder, tmp_path: Path) -> None:
+    """Loading a VLAD file with the Fisher loader raises ``ValueError``."""
+    path = learned_vlad.save_to_disk(tmp_path / "model")
+    with pytest.raises(ValueError, match="was saved by VLADEncoder"):
+        FisherVectorEncoder.load_from_disk(path)
+
+
+def test_generate_encoding_map_returns_dict(
+    learned_vlad: VLADEncoder,
+    tmp_path: Path,
+    category_train_images_flat: list[np.ndarray],
+) -> None:
+    """``generate_encoding_map`` maps each image path to a 1-D vector."""
+    paths = []
+    for index in (0, 1):
+        gray = category_train_images_flat[index]
+        rgb = np.stack([gray, gray, gray], axis=-1)
+        path = str(tmp_path / f"img_{index}.png")
+        Image.fromarray(rgb).save(path)
+        paths.append(path)
+
+    encoding_map = learned_vlad.generate_encoding_map(paths)
+    assert set(encoding_map) == set(paths)
+    vectors = [np.asarray(vector) for vector in encoding_map.values()]
+    assert all(vector.ndim == 1 for vector in vectors)
+    assert len({vector.shape[0] for vector in vectors}) == 1
+
+
+def test_repr_smoke(learned_vlad: VLADEncoder) -> None:
+    """``repr`` names the encoder class and its RootSIFT feature extractor."""
+    text = repr(learned_vlad)
+    assert "VLADEncoder(" in text
+    assert "feature_extractor=RootSIFT" in text

--- a/tests/encoders/test_behavioural.py
+++ b/tests/encoders/test_behavioural.py
@@ -1,0 +1,310 @@
+"""Behavioural / requirement-driven encoder tests.
+
+These integration tests learn a visual vocabulary and then assert the ordering
+of similarity scores. Each behaviour is checked for both encoders (via the
+``learned_vlad_encoder`` / ``learned_fisher_encoder`` fixtures, which are
+themselves parametrized over a non-PCA and a PCA variant), so every assertion
+runs across the full encoder x PCA matrix.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+from pyvisim.encoders import FisherVectorEncoder, Pipeline, VLADEncoder
+
+if TYPE_CHECKING:
+    from pyvisim._base_classes import SimilarityMetric
+    from tests.conftest import ImageObj
+
+#: A small margin so ordering assertions are not decided by floating-point noise.
+MARGIN = 1e-3
+
+#: PCA variants for the pipeline behavioural test (mirrors the encoder fixtures).
+PCA_VARIANTS = [None, {"n_components": 32, "random_state": 0}]
+
+
+# Shared assertion helpers (one per behaviour, reused across both encoders)
+
+
+def _assert_same_category_higher(
+    encoder: SimilarityMetric, query_images: dict[str, list[np.ndarray]]
+) -> None:
+    """Assert same-category queries score higher than different-category ones."""
+    categories = list(query_images)
+    same_scores: list[float] = []
+    diff_scores: list[float] = []
+    for index, category in enumerate(categories):
+        other = categories[(index + 1) % len(categories)]
+        query_a, query_b = query_images[category][0], query_images[category][1]
+        query_other = query_images[other][0]
+        score_same = float(encoder.similarity_score([query_a], [query_b])[0, 0])
+        score_diff = float(encoder.similarity_score([query_a], [query_other])[0, 0])
+        assert score_same > score_diff + MARGIN
+        same_scores.append(score_same)
+        diff_scores.append(score_diff)
+    assert float(np.mean(same_scores)) > float(np.mean(diff_scores)) + MARGIN
+
+
+# §3.6.1 Category separation
+
+
+def test_same_category_scores_higher_than_different_vlad(
+    learned_vlad_encoder: VLADEncoder,
+    category_query_images: dict[str, list[np.ndarray]],
+) -> None:
+    """VLAD scores same-category query pairs higher than different-category ones."""
+    _assert_same_category_higher(learned_vlad_encoder, category_query_images)
+
+
+def test_same_category_scores_higher_than_different_fisher(
+    learned_fisher_encoder: FisherVectorEncoder,
+    category_query_images: dict[str, list[np.ndarray]],
+) -> None:
+    """Fisher scores same-category query pairs higher than different-category ones."""
+    _assert_same_category_higher(learned_fisher_encoder, category_query_images)
+
+
+def test_identical_image_near_perfect_similarity_vlad(
+    learned_vlad_encoder: VLADEncoder, checkerboard_image: ImageObj
+) -> None:
+    """VLAD reports similarity of 1.0 for an image against its copy."""
+    image = checkerboard_image.array
+    score = float(learned_vlad_encoder.similarity_score([image], [image.copy()])[0, 0])
+    assert score == pytest.approx(1.0, abs=1e-6)
+
+
+def test_identical_image_near_perfect_similarity_fisher(
+    learned_fisher_encoder: FisherVectorEncoder, checkerboard_image: ImageObj
+) -> None:
+    """Fisher reports similarity of 1.0 for an image against its copy."""
+    image = checkerboard_image.array
+    score = float(
+        learned_fisher_encoder.similarity_score([image], [image.copy()])[0, 0]
+    )
+    assert score == pytest.approx(1.0, abs=1e-6)
+
+
+def test_identical_image_near_perfect_similarity_pipeline(
+    learned_vlad_encoder: VLADEncoder,
+    learned_fisher_encoder: FisherVectorEncoder,
+    checkerboard_image: ImageObj,
+) -> None:
+    """Pipeline reports similarity of 1.0 for an image against its copy."""
+    pipeline = Pipeline([learned_vlad_encoder, learned_fisher_encoder])
+    image = checkerboard_image.array
+    score = float(pipeline.similarity_score([image], [image.copy()])[0, 0])
+    assert score == pytest.approx(1.0, abs=1e-6)
+
+
+def test_encode_deterministic_vlad(
+    learned_vlad_encoder: VLADEncoder, checkerboard_image: ImageObj
+) -> None:
+    """Encoding the same query twice with a fixed seed is reproducible."""
+    image = checkerboard_image.array
+    assert np.allclose(
+        learned_vlad_encoder.encode([image]), learned_vlad_encoder.encode([image])
+    )
+
+
+def test_encode_deterministic_fisher(
+    learned_fisher_encoder: FisherVectorEncoder, checkerboard_image: ImageObj
+) -> None:
+    """Encoding the same query twice with a fixed seed is reproducible."""
+    image = checkerboard_image.array
+    assert np.allclose(
+        learned_fisher_encoder.encode([image]), learned_fisher_encoder.encode([image])
+    )
+
+
+# §3.6.2 Noise-level ordering
+
+
+def _assert_same_noise_higher(
+    encoder: SimilarityMetric,
+    noisy_pair: tuple[ImageObj, ImageObj],
+    very_noisy_pair: tuple[ImageObj, ImageObj],
+) -> float:
+    """Assert same-level noise scores higher than different-level; return ``s_diff``."""
+    noisy_a, noisy_b = noisy_pair
+    very_noisy_a, _ = very_noisy_pair
+    score_same = float(encoder.similarity_score([noisy_a.array], [noisy_b.array])[0, 0])
+    score_diff = float(
+        encoder.similarity_score([noisy_a.array], [very_noisy_a.array])[0, 0]
+    )
+    assert score_same > score_diff + MARGIN
+    return score_diff
+
+
+def _assert_grey_is_floor(
+    encoder: SimilarityMetric, query: np.ndarray, grey: np.ndarray
+) -> None:
+    """Assert the plain grey image is the similarity floor (it cannot be encoded).
+
+    The plain grey image yields no descriptors, so the encoders raise rather
+    than producing a score: it is strictly less comparable than any encodable
+    pair, i.e. ``s_diff > s_grey``.
+    """
+    with pytest.raises(ValueError):
+        encoder.similarity_score([query], [grey])
+
+
+def test_same_noise_more_similar_than_different_noise_vlad(
+    learned_vlad_encoder: VLADEncoder,
+    noisy_image_pair: tuple[ImageObj, ImageObj],
+    very_noisy_image_pair: tuple[ImageObj, ImageObj],
+) -> None:
+    """VLAD: same noise level is more similar than a different noise level."""
+    _assert_same_noise_higher(
+        learned_vlad_encoder, noisy_image_pair, very_noisy_image_pair
+    )
+
+
+def test_same_noise_more_similar_than_different_noise_fisher(
+    learned_fisher_encoder: FisherVectorEncoder,
+    noisy_image_pair: tuple[ImageObj, ImageObj],
+    very_noisy_image_pair: tuple[ImageObj, ImageObj],
+) -> None:
+    """Fisher: same noise level is more similar than a different noise level."""
+    _assert_same_noise_higher(
+        learned_fisher_encoder, noisy_image_pair, very_noisy_image_pair
+    )
+
+
+def test_different_noise_more_similar_than_grey_vlad(
+    learned_vlad_encoder: VLADEncoder,
+    noisy_image_pair: tuple[ImageObj, ImageObj],
+    solid_image: ImageObj,
+) -> None:
+    """VLAD: a different-noise pair still beats the unencodable plain grey floor."""
+    noisy_a, _ = noisy_image_pair
+    _assert_grey_is_floor(learned_vlad_encoder, noisy_a.array, solid_image.array)
+
+
+def test_different_noise_more_similar_than_grey_fisher(
+    learned_fisher_encoder: FisherVectorEncoder,
+    noisy_image_pair: tuple[ImageObj, ImageObj],
+    solid_image: ImageObj,
+) -> None:
+    """Fisher: a different-noise pair still beats the unencodable plain grey floor."""
+    noisy_a, _ = noisy_image_pair
+    _assert_grey_is_floor(learned_fisher_encoder, noisy_a.array, solid_image.array)
+
+
+def test_full_noise_ordering_vlad(
+    learned_vlad_encoder: VLADEncoder,
+    noisy_image_pair: tuple[ImageObj, ImageObj],
+    very_noisy_image_pair: tuple[ImageObj, ImageObj],
+    solid_image: ImageObj,
+) -> None:
+    """VLAD: ``s_same > s_diff > s_grey`` as a single ordering check."""
+    _assert_same_noise_higher(
+        learned_vlad_encoder, noisy_image_pair, very_noisy_image_pair
+    )
+    _assert_grey_is_floor(
+        learned_vlad_encoder, noisy_image_pair[0].array, solid_image.array
+    )
+
+
+def test_full_noise_ordering_fisher(
+    learned_fisher_encoder: FisherVectorEncoder,
+    noisy_image_pair: tuple[ImageObj, ImageObj],
+    very_noisy_image_pair: tuple[ImageObj, ImageObj],
+    solid_image: ImageObj,
+) -> None:
+    """Fisher: ``s_same > s_diff > s_grey`` as a single ordering check."""
+    _assert_same_noise_higher(
+        learned_fisher_encoder, noisy_image_pair, very_noisy_image_pair
+    )
+    _assert_grey_is_floor(
+        learned_fisher_encoder, noisy_image_pair[0].array, solid_image.array
+    )
+
+
+# §3.6.4 Noisy image closer to original than to a different image
+
+
+def _assert_noisy_closer_to_original_than_different(
+    encoder: SimilarityMetric,
+    original: np.ndarray,
+    noisy: np.ndarray,
+    different: np.ndarray,
+) -> None:
+    """Assert ``similarity(original, noisy) > similarity(original, different)``."""
+    score_noisy = float(encoder.similarity_score([original], [noisy])[0, 0])
+    score_diff = float(encoder.similarity_score([original], [different])[0, 0])
+    assert score_noisy > score_diff + MARGIN
+
+
+def test_noisy_closer_to_original_than_different_vlad(
+    learned_vlad_encoder: VLADEncoder,
+    checkerboard_image: ImageObj,
+    noisy_checkerboard_image: ImageObj,
+    blobs_image: ImageObj,
+) -> None:
+    """VLAD: image+noise is more similar to its original than to a structurally different image."""
+    _assert_noisy_closer_to_original_than_different(
+        learned_vlad_encoder,
+        checkerboard_image.array,
+        noisy_checkerboard_image.array,
+        blobs_image.array,
+    )
+
+
+def test_noisy_closer_to_original_than_different_fisher(
+    learned_fisher_encoder: FisherVectorEncoder,
+    checkerboard_image: ImageObj,
+    noisy_checkerboard_image: ImageObj,
+    blobs_image: ImageObj,
+) -> None:
+    """Fisher: image+noise is more similar to its original than to a structurally different image."""
+    _assert_noisy_closer_to_original_than_different(
+        learned_fisher_encoder,
+        checkerboard_image.array,
+        noisy_checkerboard_image.array,
+        blobs_image.array,
+    )
+
+
+def test_noisy_closer_to_original_than_different_pipeline(
+    learned_vlad_encoder: VLADEncoder,
+    learned_fisher_encoder: FisherVectorEncoder,
+    checkerboard_image: ImageObj,
+    noisy_checkerboard_image: ImageObj,
+    blobs_image: ImageObj,
+) -> None:
+    """Pipeline: image+noise is more similar to its original than to a structurally different image."""
+    pipeline = Pipeline([learned_vlad_encoder, learned_fisher_encoder])
+    _assert_noisy_closer_to_original_than_different(
+        pipeline,
+        checkerboard_image.array,
+        noisy_checkerboard_image.array,
+        blobs_image.array,
+    )
+
+
+# §3.6.3 Pipeline behavioural
+
+
+@pytest.mark.parametrize("pca_params", PCA_VARIANTS, ids=["no_pca", "pca32"])
+def test_pipeline_same_category_higher(
+    category_train_images_flat: list[np.ndarray],
+    category_query_images: dict[str, list[np.ndarray]],
+    pca_params: dict[str, int] | None,
+) -> None:
+    """A VLAD+Fisher pipeline scores same-category pairs higher than different ones."""
+    vlad = VLADEncoder(
+        n_clusters=8,
+        kmeans_params={"random_state": 0, "n_init": 3},
+        pca_params=pca_params,
+    )
+    fisher = FisherVectorEncoder(
+        n_components=8, gmm_params={"random_state": 0}, pca_params=pca_params
+    )
+    vlad.learn(category_train_images_flat)
+    fisher.learn(category_train_images_flat)
+    pipeline = Pipeline([vlad, fisher])
+    _assert_same_category_higher(pipeline, category_query_images)

--- a/tests/encoders/test_fisher_vector.py
+++ b/tests/encoders/test_fisher_vector.py
@@ -1,0 +1,119 @@
+"""Tests for :class:`pyvisim.encoders.FisherVectorEncoder`."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+import torch
+from sklearn.exceptions import NotFittedError
+
+from pyvisim.clustering import GaussianMixtureModel, KMeans
+from pyvisim.encoders import FisherVectorEncoder, KMeansWeights
+
+if TYPE_CHECKING:
+    from tests.conftest import ImageObj
+
+#: Fisher output width for ``k=8`` and RootSIFT (128-d): ``2 * 8 * 128 + 8``.
+FISHER_DIM_NO_PCA = 2 * 8 * 128 + 8
+#: Fisher output width with PCA to 32 dimensions: ``2 * 8 * 32 + 8``.
+FISHER_DIM_PCA = 2 * 8 * 32 + 8
+
+
+@pytest.fixture(scope="module")
+def fisher_no_pca(category_train_images_flat: list[np.ndarray]) -> FisherVectorEncoder:
+    """A learned ``FisherVectorEncoder(n_components=8)`` without PCA.
+
+    :param category_train_images_flat: flattened training images to learn from.
+    :returns: a fitted ``FisherVectorEncoder``.
+    """
+    encoder = FisherVectorEncoder(n_components=8, gmm_params={"random_state": 0})
+    encoder.learn(category_train_images_flat)
+    return encoder
+
+
+@pytest.fixture(scope="module")
+def fisher_pca(category_train_images_flat: list[np.ndarray]) -> FisherVectorEncoder:
+    """A learned ``FisherVectorEncoder(n_components=8)`` with PCA to 32 dimensions.
+
+    :param category_train_images_flat: flattened training images to learn from.
+    :returns: a fitted ``FisherVectorEncoder``.
+    """
+    encoder = FisherVectorEncoder(
+        n_components=8,
+        gmm_params={"random_state": 0},
+        pca_params={"n_components": 32, "random_state": 0},
+    )
+    encoder.learn(category_train_images_flat)
+    return encoder
+
+
+def test_fisher_clustering_model_type() -> None:
+    """Fisher builds a Gaussian mixture clustering model."""
+    model = FisherVectorEncoder(n_components=8).clustering_model
+    assert isinstance(model, GaussianMixtureModel)
+
+
+def test_fisher_n_components_kwargs_collision() -> None:
+    """Passing ``n_components`` inside ``gmm_params`` raises ``ValueError``."""
+    with pytest.raises(ValueError, match="Pass 'n_components' directly"):
+        FisherVectorEncoder(gmm_params={"n_components": 8})
+
+
+def test_fisher_wrong_weights_class_raises() -> None:
+    """Passing KMeans weights to Fisher raises ``ValueError``."""
+    with pytest.raises(ValueError, match="only pass an instance of GMMWeights"):
+        FisherVectorEncoder(weights=KMeansWeights.OXFORD102_K256_SIFT)
+
+
+def test_fisher_clustering_setter_rejects_non_gmm() -> None:
+    """Assigning a non-GMM clustering model raises ``ValueError``."""
+    encoder = FisherVectorEncoder(n_components=8)
+    with pytest.raises(ValueError, match="GaussianMixtureModel"):
+        encoder.clustering_model = KMeans(8)
+
+
+def test_fisher_encode_shape_no_pca(
+    fisher_no_pca: FisherVectorEncoder, checkerboard_image: ImageObj
+) -> None:
+    """Without PCA, a single image encodes to ``(1, 2 * k * 128 + k)``."""
+    out = fisher_no_pca.encode([checkerboard_image.array])
+    assert out.shape == (1, FISHER_DIM_NO_PCA)
+
+
+def test_fisher_encode_shape_with_pca(
+    fisher_pca: FisherVectorEncoder, checkerboard_image: ImageObj
+) -> None:
+    """With PCA to 32 dims, a single image encodes to ``(1, 2 * k * 32 + k)``."""
+    out = fisher_pca.encode([checkerboard_image.array])
+    assert out.shape == (1, FISHER_DIM_PCA)
+
+
+def test_fisher_encode_batch_shape(
+    fisher_no_pca: FisherVectorEncoder, checkerboard_image: ImageObj
+) -> None:
+    """A batch of two images encodes to ``(2, 2 * k * 128 + k)``."""
+    base = checkerboard_image.array
+    batch = [base, np.roll(base, 8, axis=0)]
+    assert fisher_no_pca.encode(batch).shape == (2, FISHER_DIM_NO_PCA)
+
+
+def test_fisher_encode_rejects_tensor(fisher_no_pca: FisherVectorEncoder) -> None:
+    """Encoding a torch tensor raises ``RuntimeError``."""
+    with pytest.raises(RuntimeError, match="Torch images are not supported"):
+        fisher_no_pca.encode(torch.zeros(3, 64, 64))
+
+
+def test_fisher_encode_no_descriptors(
+    fisher_no_pca: FisherVectorEncoder, solid_image: ImageObj
+) -> None:
+    """Encoding a featureless image raises (GMM cannot score zero descriptors)."""
+    with pytest.raises(ValueError):
+        fisher_no_pca.encode([solid_image.array])
+
+
+def test_fisher_before_learn_raises(checkerboard_image: ImageObj) -> None:
+    """Encoding before learning raises ``NotFittedError`` (GMM not fitted)."""
+    with pytest.raises(NotFittedError):
+        FisherVectorEncoder(n_components=8).encode([checkerboard_image.array])

--- a/tests/encoders/test_pipeline.py
+++ b/tests/encoders/test_pipeline.py
@@ -1,0 +1,134 @@
+"""Tests for :class:`pyvisim.encoders.Pipeline`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from pyvisim.encoders import FisherVectorEncoder, Pipeline, VLADEncoder
+
+if TYPE_CHECKING:
+    from tests.conftest import ImageObj
+
+#: Combined pipeline width: VLAD (``8 * 128``) concatenated with Fisher
+#: (``2 * 8 * 128 + 8``).
+PIPELINE_DIM = 8 * 128 + (2 * 8 * 128 + 8)
+
+
+@pytest.fixture(scope="module")
+def pipeline_encoders(
+    category_train_images_flat: list[np.ndarray],
+) -> tuple[VLADEncoder, FisherVectorEncoder]:
+    """A learned VLAD and Fisher encoder, both sharing the default RootSIFT.
+
+    :param category_train_images_flat: flattened training images to learn from.
+    :returns: a ``(vlad, fisher)`` tuple of fitted encoders.
+    """
+    vlad = VLADEncoder(n_clusters=8, kmeans_params={"random_state": 0, "n_init": 3})
+    fisher = FisherVectorEncoder(n_components=8, gmm_params={"random_state": 0})
+    vlad.learn(category_train_images_flat)
+    fisher.learn(category_train_images_flat)
+    return vlad, fisher
+
+
+@pytest.fixture(scope="module")
+def pipeline(
+    pipeline_encoders: tuple[VLADEncoder, FisherVectorEncoder],
+) -> Pipeline:
+    """A pipeline combining the learned VLAD and Fisher encoders.
+
+    :param pipeline_encoders: the ``(vlad, fisher)`` fixture.
+    :returns: a ``Pipeline`` over both encoders.
+    """
+    vlad, fisher = pipeline_encoders
+    return Pipeline([vlad, fisher])
+
+
+def test_pipeline_rejects_non_encoder() -> None:
+    """A pipeline rejects members that are not encoders."""
+    with pytest.raises(ValueError, match="only accepts instances of ImageEncoderBase"):
+        Pipeline(["not an encoder"])  # type: ignore[list-item]
+
+
+def test_pipeline_encode_concatenates(
+    pipeline: Pipeline, checkerboard_image: ImageObj
+) -> None:
+    """The pipeline concatenates each encoder's output along the feature axis."""
+    out = pipeline.encode([checkerboard_image.array])
+    assert out.shape == (1, PIPELINE_DIM)
+
+
+def test_pipeline_restores_flatten_flag(
+    pipeline: Pipeline,
+    pipeline_encoders: tuple[VLADEncoder, FisherVectorEncoder],
+    checkerboard_image: ImageObj,
+) -> None:
+    """The pipeline restores each encoder's original ``flatten`` flag."""
+    vlad, _ = pipeline_encoders
+    original = vlad.flatten
+    vlad.flatten = False
+    try:
+        pipeline.encode([checkerboard_image.array])
+        assert vlad.flatten is False
+    finally:
+        vlad.flatten = original
+
+
+def test_pipeline_encode_batch(
+    pipeline: Pipeline, checkerboard_image: ImageObj
+) -> None:
+    """A batch of two images encodes to ``(2, PIPELINE_DIM)``."""
+    base = checkerboard_image.array
+    batch = [base, np.roll(base, 8, axis=0)]
+    assert pipeline.encode(batch).shape == (2, PIPELINE_DIM)
+
+
+def test_pipeline_encode_rejects_tensor(pipeline: Pipeline) -> None:
+    """Encoding a torch tensor raises ``RuntimeError``."""
+    with pytest.raises(RuntimeError, match="Torch images are not supported"):
+        pipeline.encode(torch.zeros(3, 64, 64))
+
+
+def test_pipeline_similarity_score_shape(
+    pipeline: Pipeline, checkerboard_image: ImageObj
+) -> None:
+    """``similarity_score`` returns an ``(n1, n2)`` float32 matrix."""
+    base = checkerboard_image.array
+    images1 = [base, np.roll(base, 8, axis=0)]
+    images2 = [np.roll(base, 8, axis=1)]
+    scores = pipeline.similarity_score(images1, images2)
+    assert scores.shape == (2, 1)
+    assert scores.dtype == np.float32
+
+
+def test_pipeline_generate_encoding_map(
+    pipeline: Pipeline,
+    tmp_path: Path,
+    category_train_images_flat: list[np.ndarray],
+) -> None:
+    """``generate_encoding_map`` maps each path to an equal-length vector."""
+    paths = []
+    for index in (0, 1):
+        gray = category_train_images_flat[index]
+        rgb = np.stack([gray, gray, gray], axis=-1)
+        path = str(tmp_path / f"img_{index}.png")
+        Image.fromarray(rgb).save(path)
+        paths.append(path)
+
+    encoding_map = pipeline.generate_encoding_map(paths)
+    assert set(encoding_map) == set(paths)
+    lengths = {np.asarray(vector).shape[0] for vector in encoding_map.values()}
+    assert len(lengths) == 1
+
+
+def test_pipeline_repr(pipeline: Pipeline) -> None:
+    """``repr`` names the pipeline and each member encoder."""
+    text = repr(pipeline)
+    assert "Pipeline(" in text
+    assert "VLADEncoder(" in text
+    assert "FisherVectorEncoder(" in text

--- a/tests/encoders/test_vlad.py
+++ b/tests/encoders/test_vlad.py
@@ -1,0 +1,147 @@
+"""Tests for :class:`pyvisim.encoders.VLADEncoder`."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+import torch
+from sklearn.exceptions import NotFittedError
+
+from pyvisim.clustering import GaussianMixtureModel, KMeans
+from pyvisim.encoders import GMMWeights, VLADEncoder
+
+if TYPE_CHECKING:
+    from tests.conftest import ImageObj
+
+#: VLAD output width for ``n_clusters=8`` and RootSIFT (128-d): ``8 * 128``.
+VLAD_DIM_NO_PCA = 8 * 128
+#: VLAD output width with PCA to 32 dimensions: ``8 * 32``.
+VLAD_DIM_PCA = 8 * 32
+
+
+@pytest.fixture(scope="module")
+def vlad_no_pca(category_train_images_flat: list[np.ndarray]) -> VLADEncoder:
+    """A learned ``VLADEncoder(n_clusters=8)`` without PCA.
+
+    :param category_train_images_flat: flattened training images to learn from.
+    :returns: a fitted ``VLADEncoder``.
+    """
+    encoder = VLADEncoder(n_clusters=8, kmeans_params={"random_state": 0, "n_init": 3})
+    encoder.learn(category_train_images_flat)
+    return encoder
+
+
+@pytest.fixture(scope="module")
+def vlad_pca(category_train_images_flat: list[np.ndarray]) -> VLADEncoder:
+    """A learned ``VLADEncoder(n_clusters=8)`` with PCA to 32 dimensions.
+
+    :param category_train_images_flat: flattened training images to learn from.
+    :returns: a fitted ``VLADEncoder``.
+    """
+    encoder = VLADEncoder(
+        n_clusters=8,
+        kmeans_params={"random_state": 0, "n_init": 3},
+        pca_params={"n_components": 32, "random_state": 0},
+    )
+    encoder.learn(category_train_images_flat)
+    return encoder
+
+
+def test_vlad_clustering_model_type() -> None:
+    """VLAD builds a KMeans clustering model."""
+    assert isinstance(VLADEncoder(n_clusters=8).clustering_model, KMeans)
+
+
+def test_vlad_n_clusters_param_kwargs_collision() -> None:
+    """Passing ``n_clusters`` inside ``kmeans_params`` raises ``ValueError``."""
+    with pytest.raises(ValueError, match="Pass 'n_clusters' directly"):
+        VLADEncoder(kmeans_params={"n_clusters": 8})
+
+
+def test_vlad_wrong_weights_class_raises() -> None:
+    """Passing GMM weights to VLAD raises ``ValueError``."""
+    with pytest.raises(ValueError, match="only pass an instance of KMeansWeights"):
+        VLADEncoder(weights=GMMWeights.OXFORD102_K256_SIFT)
+
+
+def test_vlad_clustering_setter_rejects_non_kmeans() -> None:
+    """Assigning a non-KMeans clustering model raises ``ValueError``."""
+    encoder = VLADEncoder(n_clusters=8)
+    with pytest.raises(
+        ValueError, match="must be an instance of pyvisim.clustering.KMeans"
+    ):
+        encoder.clustering_model = GaussianMixtureModel(8)
+
+
+def test_vlad_encode_shape_no_pca(
+    vlad_no_pca: VLADEncoder, checkerboard_image: ImageObj
+) -> None:
+    """Without PCA, a single image encodes to ``(1, n_clusters * 128)``."""
+    out = vlad_no_pca.encode([checkerboard_image.array])
+    assert out.shape == (1, VLAD_DIM_NO_PCA)
+
+
+def test_vlad_encode_batch_shape(
+    vlad_no_pca: VLADEncoder, checkerboard_image: ImageObj
+) -> None:
+    """A batch of three images encodes to ``(3, n_clusters * 128)``."""
+    base = checkerboard_image.array
+    batch = [base, np.roll(base, 8, axis=0), np.roll(base, 8, axis=1)]
+    assert vlad_no_pca.encode(batch).shape == (3, VLAD_DIM_NO_PCA)
+
+
+def test_vlad_encode_shape_with_pca(
+    vlad_pca: VLADEncoder, checkerboard_image: ImageObj
+) -> None:
+    """With PCA to 32 dims, a single image encodes to ``(1, n_clusters * 32)``."""
+    out = vlad_pca.encode([checkerboard_image.array])
+    assert out.shape == (1, VLAD_DIM_PCA)
+
+
+def test_vlad_encode_rows_l2_normalized(
+    vlad_no_pca: VLADEncoder, checkerboard_image: ImageObj
+) -> None:
+    """Each non-zero cluster row of the encoding has unit L2 norm."""
+    out = vlad_no_pca.encode([checkerboard_image.array]).reshape(8, 128)
+    norms = np.linalg.norm(out, axis=1)
+    non_zero = norms[norms > 1e-6]
+    assert non_zero == pytest.approx(np.ones_like(non_zero), rel=1e-3)
+
+
+def test_vlad_encode_single_rgb_image_ok(
+    vlad_no_pca: VLADEncoder, rgb_image: ImageObj
+) -> None:
+    """A bare 3-D RGB array is treated as a single image."""
+    assert vlad_no_pca.encode(rgb_image.array).shape == (1, VLAD_DIM_NO_PCA)
+
+
+def test_vlad_encode_single_2d_must_be_wrapped(
+    vlad_no_pca: VLADEncoder, checkerboard_image: ImageObj
+) -> None:
+    """A single 2-D image must be wrapped in a list; a bare 2-D array iterates rows."""
+    gray = checkerboard_image.array
+    assert vlad_no_pca.encode([gray]).shape == (1, VLAD_DIM_NO_PCA)
+    with pytest.raises(ValueError):
+        vlad_no_pca.encode(gray)
+
+
+def test_vlad_encode_no_descriptors_raises(
+    vlad_no_pca: VLADEncoder, solid_image: ImageObj
+) -> None:
+    """Encoding a featureless image raises a clear ``ValueError``."""
+    with pytest.raises(ValueError, match="No descriptors found in the image"):
+        vlad_no_pca.encode([solid_image.array])
+
+
+def test_vlad_encode_rejects_tensor(vlad_no_pca: VLADEncoder) -> None:
+    """Encoding a torch tensor raises ``RuntimeError``."""
+    with pytest.raises(RuntimeError, match="Torch images are not supported"):
+        vlad_no_pca.encode(torch.zeros(3, 64, 64))
+
+
+def test_vlad_predict_before_learn_raises(checkerboard_image: ImageObj) -> None:
+    """Encoding before learning raises ``NotFittedError`` (KMeans not fitted)."""
+    with pytest.raises(NotFittedError):
+        VLADEncoder(n_clusters=8).encode([checkerboard_image.array])

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -1,0 +1,299 @@
+"""Tests for the feature extractors in :mod:`pyvisim.features`."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+from pyvisim.features import SIFT, DeepConvFeature, Lambda, RootSIFT
+
+if TYPE_CHECKING:
+    from tests.conftest import ImageObj
+
+#: Image fixtures of varying sizes; extractors must honour the shape contract
+#: regardless of input size (the requirement only exercises extractors here).
+VARYING_SIZE_FIXTURES = ["small_image", "large_image", "non_square_image", "rgb_image"]
+
+
+def _tiny_conv_model() -> nn.Module:
+    """Build a tiny two-conv-layer network to avoid downloading VGG16.
+
+    :returns: a ``torch.nn.Sequential`` with two ``Conv2d`` layers (6 then 10
+        output channels) separated by a ReLU.
+    """
+    return nn.Sequential(
+        nn.Conv2d(3, 6, 3, padding=1),
+        nn.ReLU(),
+        nn.Conv2d(6, 10, 3, padding=1),
+    )
+
+
+# ---------------------------------------------------------------------------
+# SIFT
+# ---------------------------------------------------------------------------
+
+
+def test_sift_output_dim() -> None:
+    """SIFT descriptors are 128-dimensional."""
+    assert SIFT().output_dim == 128
+
+
+def test_sift_extracts_descriptors(checkerboard_image: ImageObj) -> None:
+    """A corner-rich image yields a non-empty ``(N, 128)`` float32 matrix."""
+    out = SIFT()(checkerboard_image.array)
+    assert out.ndim == 2
+    assert out.shape[1] == 128
+    assert out.shape[0] > 0
+    assert out.dtype == np.float32
+
+
+def test_sift_featureless_returns_empty(solid_image: ImageObj) -> None:
+    """A featureless image yields an empty ``(0, 128)`` array."""
+    assert SIFT()(solid_image.array).shape == (0, 128)
+
+
+def test_sift_stripes_returns_empty(stripes_image: ImageObj) -> None:
+    """A stripe pattern has no SIFT corners, yielding an empty array."""
+    assert SIFT()(stripes_image.array).shape == (0, 128)
+
+
+def test_sift_tiny_returns_empty(tiny_image: ImageObj) -> None:
+    """An 8x8 image is too small for keypoints, yielding an empty array."""
+    assert SIFT()(tiny_image.array).shape == (0, 128)
+
+
+def test_sift_rejects_tensor() -> None:
+    """Passing a torch tensor raises ``TypeError``."""
+    with pytest.raises(TypeError):
+        SIFT()(torch.zeros(3, 64, 64))
+
+
+def test_sift_repr() -> None:
+    """``repr`` reports the extractor name and its output dimension."""
+    assert repr(SIFT()) == "SIFT(output_dim=128)"
+
+
+@pytest.mark.parametrize("image_fixture", VARYING_SIZE_FIXTURES)
+def test_sift_varying_sizes(request: pytest.FixtureRequest, image_fixture: str) -> None:
+    """SIFT honours the ``(N, 128)`` shape contract across input sizes."""
+    image = request.getfixturevalue(image_fixture).array
+    out = SIFT()(image)
+    assert out.ndim == 2
+    assert out.shape[1] == 128
+
+
+# RootSIFT (default extractor)
+
+
+def test_rootsift_output_dim() -> None:
+    """RootSIFT descriptors are 128-dimensional."""
+    assert RootSIFT().output_dim == 128
+
+
+def test_rootsift_extracts_descriptors(checkerboard_image: ImageObj) -> None:
+    """A corner-rich image yields a non-empty ``(N, 128)`` float32 matrix."""
+    out = RootSIFT()(checkerboard_image.array)
+    assert out.ndim == 2
+    assert out.shape[1] == 128
+    assert out.shape[0] > 0
+    assert out.dtype == np.float32
+
+
+def test_rootsift_values_non_negative(checkerboard_image: ImageObj) -> None:
+    """RootSIFT values are non-negative (square root of a normalized histogram)."""
+    out = RootSIFT()(checkerboard_image.array)
+    assert np.all(out >= 0)
+
+
+def test_rootsift_rows_l2_normalized(checkerboard_image: ImageObj) -> None:
+    """Each RootSIFT descriptor row has unit L2 norm."""
+    out = RootSIFT()(checkerboard_image.array)
+    norms = np.linalg.norm(out, axis=1)
+    assert norms == pytest.approx(np.ones_like(norms), rel=1e-3)
+
+
+def test_rootsift_featureless_returns_empty(solid_image: ImageObj) -> None:
+    """A featureless image yields an empty ``(0, 128)`` array."""
+    assert RootSIFT()(solid_image.array).shape == (0, 128)
+
+
+def test_rootsift_low_contrast_returns_empty() -> None:
+    """A low-contrast checkerboard (values 120/136) yields no descriptors."""
+    rows, cols = np.indices((256, 256)) // 16
+    pattern = (rows + cols) % 2
+    image = np.where(pattern == 0, 120, 136).astype(np.uint8)
+    assert RootSIFT()(image).shape == (0, 128)
+
+
+def test_rootsift_rejects_tensor() -> None:
+    """Passing a torch tensor raises ``TypeError``."""
+    with pytest.raises(TypeError):
+        RootSIFT()(torch.zeros(3, 64, 64))
+
+
+def test_rootsift_repr() -> None:
+    """``repr`` reports the extractor name and its output dimension."""
+    assert repr(RootSIFT()) == "RootSIFT(output_dim=128)"
+
+
+@pytest.mark.parametrize("image_fixture", VARYING_SIZE_FIXTURES)
+def test_rootsift_varying_sizes(
+    request: pytest.FixtureRequest, image_fixture: str
+) -> None:
+    """RootSIFT honours the ``(N, 128)`` shape contract across input sizes."""
+    image = request.getfixturevalue(image_fixture).array
+    out = RootSIFT()(image)
+    assert out.ndim == 2
+    assert out.shape[1] == 128
+
+
+# Lambda
+
+
+def test_lambda_non_callable_raises() -> None:
+    """Constructing ``Lambda`` with a non-callable raises ``ValueError``."""
+    with pytest.raises(ValueError, match="must be a callable"):
+        Lambda(123, output_dim=4)  # type: ignore[arg-type]
+
+
+def test_lambda_output_dim() -> None:
+    """``output_dim`` reflects the constructor argument."""
+    extractor = Lambda(lambda image: np.ones((5, 4), np.float32), output_dim=4)
+    assert extractor.output_dim == 4
+
+
+def test_lambda_happy_path(checkerboard_image: ImageObj) -> None:
+    """A well-behaved function passes through the shape validation."""
+    extractor = Lambda(lambda image: np.ones((5, 4), np.float32), output_dim=4)
+    out = extractor(checkerboard_image.array)
+    assert out.shape == (5, 4)
+    assert out.dtype == np.float32
+
+
+def test_lambda_wrong_dim_raises(checkerboard_image: ImageObj) -> None:
+    """A function whose output width mismatches ``output_dim`` raises ``ValueError``."""
+    extractor = Lambda(lambda image: np.ones((5, 3), np.float32), output_dim=4)
+    with pytest.raises(ValueError, match=r"Expected feat_vecs.shape\[1\] == 4"):
+        extractor(checkerboard_image.array)
+
+
+def test_lambda_non_2d_raises(checkerboard_image: ImageObj) -> None:
+    """A function returning a non-2D array raises ``ValueError``."""
+    extractor = Lambda(lambda image: np.ones((4,), np.float32), output_dim=4)
+    with pytest.raises(ValueError, match="must be 2D"):
+        extractor(checkerboard_image.array)
+
+
+def test_lambda_non_ndarray_raises(checkerboard_image: ImageObj) -> None:
+    """A function returning a non-array raises ``ValueError``."""
+    extractor = Lambda(lambda image: [[1, 2, 3, 4]], output_dim=4)
+    with pytest.raises(ValueError, match="Expected output to be a NumPy array"):
+        extractor(checkerboard_image.array)
+
+
+def test_lambda_none_returns_empty(checkerboard_image: ImageObj) -> None:
+    """A function returning ``None`` yields an empty ``(0, output_dim)`` array."""
+    extractor = Lambda(lambda image: None, output_dim=4)
+    assert extractor(checkerboard_image.array).shape == (0, 4)
+
+
+def test_lambda_rejects_tensor() -> None:
+    """Passing a torch tensor raises ``TypeError`` before the function runs."""
+    extractor = Lambda(lambda image: np.ones((5, 4), np.float32), output_dim=4)
+    with pytest.raises(TypeError):
+        extractor(torch.zeros(3, 8, 8))
+
+
+# DeepConvFeature
+
+
+def test_deepconv_output_dim_with_spatial() -> None:
+    """With spatial encoding, ``output_dim`` is channels + 2."""
+    extractor = DeepConvFeature(
+        _tiny_conv_model(), layer_index=-1, spatial_encoding=True, device="cpu"
+    )
+    assert extractor.output_dim == 12
+
+
+def test_deepconv_output_dim_no_spatial() -> None:
+    """Without spatial encoding, ``output_dim`` is the channel count."""
+    extractor = DeepConvFeature(
+        _tiny_conv_model(), layer_index=-1, spatial_encoding=False, device="cpu"
+    )
+    assert extractor.output_dim == 10
+
+
+def test_deepconv_call_shape_with_spatial(rgb_image: ImageObj) -> None:
+    """The call flattens the feature map to ``(Hf*Wf, output_dim)`` float32."""
+    extractor = DeepConvFeature(
+        _tiny_conv_model(), layer_index=-1, spatial_encoding=True, device="cpu"
+    )
+    out = extractor(rgb_image.array)
+    assert out.ndim == 2
+    assert out.shape[1] == 12
+    assert out.shape[0] == 224 * 224
+    assert out.dtype == np.float32
+
+
+def test_deepconv_call_shape_no_spatial(rgb_image: ImageObj) -> None:
+    """Without spatial encoding the flattened map has ``output_dim`` columns."""
+    extractor = DeepConvFeature(
+        _tiny_conv_model(), layer_index=-1, spatial_encoding=False, device="cpu"
+    )
+    out = extractor(rgb_image.array)
+    assert out.shape == (224 * 224, 10)
+
+
+def test_deepconv_list_conv_layers() -> None:
+    """``list_conv_layers`` enumerates the conv layers as ``(idx, name, module)``."""
+    extractor = DeepConvFeature(_tiny_conv_model(), device="cpu")
+    layers = extractor.list_conv_layers()
+    assert len(layers) == 2
+    for index, name, module in layers:
+        assert isinstance(index, int)
+        assert isinstance(name, str)
+        assert isinstance(module, nn.Conv2d)
+
+
+def test_deepconv_no_conv_layers_raises() -> None:
+    """A model with no conv layers raises ``ValueError``."""
+    with pytest.raises(ValueError, match="No convolutional layers found"):
+        DeepConvFeature(nn.Sequential(nn.ReLU()), device="cpu")
+
+
+def test_deepconv_layer_index_out_of_range_raises() -> None:
+    """A ``layer_index`` beyond the available conv layers raises ``IndexError``."""
+    with pytest.raises(IndexError, match="has only 2 convolutional layers"):
+        DeepConvFeature(_tiny_conv_model(), layer_index=5, device="cpu")
+
+
+def test_deepconv_bad_submodule_raises() -> None:
+    """An unknown ``target_submodule`` raises ``AttributeError``."""
+    with pytest.raises(AttributeError):
+        DeepConvFeature(
+            _tiny_conv_model(), target_submodule="does_not_exist", device="cpu"
+        )
+
+
+def test_deepconv_non_module_model_raises() -> None:
+    """A model that is not a ``torch.nn.Module`` raises ``TypeError``."""
+    with pytest.raises(TypeError):
+        DeepConvFeature(model="not a module", device="cpu")  # type: ignore[arg-type]
+
+
+def test_deepconv_rejects_tensor() -> None:
+    """Passing a torch tensor raises ``TypeError``."""
+    extractor = DeepConvFeature(_tiny_conv_model(), device="cpu")
+    with pytest.raises(TypeError):
+        extractor(torch.zeros(3, 64, 64))
+
+
+@pytest.mark.slow
+def test_deepconv_default_vgg16() -> None:
+    """The default VGG16 last conv layer gives ``output_dim == 514`` (512 + 2)."""
+    extractor = DeepConvFeature(device="cpu")
+    assert extractor.output_dim == 514


### PR DESCRIPTION
### Related Issues

- fixes 
- 
### Proposed Changes

This PR adds a full unit test suite for `pyvisim` — covering clustering models, encoders (VLAD, Fisher Vector, pipeline), feature extraction, and the Oxford Flowers dataset loader — along with the CI jobs and developer tooling to run them.

Concretely:

- **`tests/conftest.py`** — shared fixtures for synthetic images (checkerboard, gradient, blobs, solid, noisy pairs, etc.) and session-scoped pre-fitted `VLADEncoder` / `FisherVectorEncoder` instances, parametrized with and without PCA. All fixtures dump generated images to `tests/debug/` so failures can be inspected visually.
- **`tests/`** — 11 test modules covering every major subsystem: `clustering/` (KMeans, GMM, PCA, base), `encoders/` (base, VLAD, Fisher Vector, pipeline, and a behavioural suite), `features/`, and `datasets/`.
- **`tests/datasets/test_datasets.py`** — all IO is mocked; the suite never hits the network or reads real Oxford-102 data.
- **`pyproject.toml`** — added a `[test]` dependency group (`pytest`, `pytest-cov`), `pytest.ini_options` with branch coverage always on, and the `slow` marker to gate weight-downloading tests.
- **`.github/workflows/ci.yml`** — two new CI jobs: `tests` (fast, `not slow`, ubuntu + windows) and `slow-tests` (slow/integration, same matrix). Both use `uv sync --group test`.
- **`Makefile`** — `make test-unit` and `make test-slow` targets for local development.

### How did you test it?

The tests are the verification. Fast tests (`make test-unit` / `pytest -m "not slow"`) run locally with currently 1 failed test (FAILED tests/datasets/test_datasets.py::test_combined_purposes_dedup - TypeError: 'int' object is not iterable). Slow/integration tests (`make test-slow`) run against real model weights and are separated by the `slow` marker so they don't block everyday development. Both jobs pass on the CI matrix (ubuntu-latest, windows-latest).

### Notes for the reviewer

- The `conftest.py` fixture design avoids real images entirely — synthetic images (checkerboard patterns, random blobs, gradients) are reproducible, fast, and don't introduce external data dependencies. The session-scoped learned encoder fixtures (`learned_vlad_encoder`, `learned_fisher_encoder`) are parametrized over PCA on/off so dependent tests double-cover both code paths without duplicating test logic.
- The `tests/debug/` directory is regenerated fresh before each session (`shutil.rmtree` + `mkdir`). It's intentionally left out of version control so reviewers can run the tests and inspect the actual images that were fed to each test case.
- Dataset tests mock at the `pyvisim.datasets.datasets` attribute level (not the original module), which keeps the patches tight and avoids the classic `mock.patch` import-path pitfall.
-- Currently, test "FAILED tests/datasets/test_datasets.py::test_combined_purposes_dedup - TypeError: 'int' object is not iterable" fails!

### Checklist

- [ ] I have read the [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md).
- [ ] I have updated the related issue with new insights and changes.
- [ ] I have added unit tests and updated the docstrings.
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [ ] I have documented my code.
- [ ] When applicable: I have reviewed the AI-generated code sections, according to [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#using-ai-to-contribute).
- [ ] I have run [pre-commit hooks](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#set-up-developer-environment) and fixed any issue.
