### PR TITLE
bugfix: use flatten() instead of squeeze() for setid arrays

### DIFF
--- a/pyvisim/datasets/datasets.py
+++ b/pyvisim/datasets/datasets.py
@@ -269,10 +269,10 @@ class OxfordFlowerDataset(Dataset[tuple[UInt8NumpyArray, int, str]]):
         """
         mat_data = scipy.io.loadmat(set_id_file)
         train_ids = (
-            mat_data["tstid"].squeeze().tolist()
+            mat_data["tstid"].flatten().tolist()
         )  # Swaps train and test, since test contains significantly more images
-        val_ids = mat_data["valid"].squeeze().tolist()
-        test_ids = mat_data["trnid"].squeeze().tolist()
+        val_ids = mat_data["valid"].flatten().tolist()
+        test_ids = mat_data["trnid"].flatten().tolist()
         return train_ids, val_ids, test_ids
 
     def _filter_by_purpose(self) -> tuple[list[str], list[int]]:


### PR DESCRIPTION
### Related Issues

- fixes #

### Proposed Changes:

`OxfordFlowerDataset` was crashing with `TypeError: 'int' object is not iterable` whenever a split contained only a single image ID (e.g. the validation set in tests). The culprit was `.squeeze().tolist()` in `_load_set_ids`: NumPy's `squeeze()` collapses a single-element 2-D array all the way down to a 0-d array, and calling `.tolist()` on a 0-d array returns a bare scalar rather than a list. Replacing `.squeeze()` with `.flatten()` fixes it — `flatten()` always yields a 1-D array, so `.tolist()` always produces a list regardless of how many IDs a split contains.

The change is three lines in `pyvisim/datasets/datasets.py`, applied consistently to all three split arrays (`tstid`/`train`, `valid`/`validation`, `trnid`/`test`).

### How did you test it?

The existing test suite covers this — `test_combined_purposes_dedup` in `tests/datasets/test_datasets.py` mocks `"valid"` as `np.array([[3]])` (a single-element array) and was the failing test. All 195 non-slow unit tests pass after the fix, and mypy reports no issues.

### Notes for the reviewer

The root cause is a subtle NumPy gotcha: `squeeze()` is often used casually to "remove extra dimensions," but it silently over-squeezes when the array has only one element along every axis. `flatten()` is the safer choice here because it unconditionally returns 1-D output.

### Checklist

- [ ] I have read the [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md).
- [ ] I have updated the related issue with new insights and changes.
- [ ] I have added unit tests and updated the docstrings.
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [ ] I have documented my code.
- [ ] When applicable: I have reviewed the AI-generated code sections, according to [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#using-ai-to-contribute).
- [ ] I have run [pre-commit hooks](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#set-up-developer-environment) and fixed any issue.
