### PR TITLE
Fix deprecated project.license TOML table in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0", "wheel"]
+requires = ["setuptools>=77.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +7,8 @@ name = "pyvisim"
 version = "0.2.0"
 description = "A Python library for image similarity analysis using Image Encoders and Neural Networks"
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     {name = "Nhat Huy Vu", email = "vunhathuy234@gmail.com"}
 ]


### PR DESCRIPTION
Use a SPDX license expression string and license-files instead of the deprecated `license = {text = "MIT"}` table form, which setuptools warns about and will drop support for by 2027-02-18. Bump the build requirement to setuptools>=77.0.0 since the new format needs it.
