### PR TITLE
Feat: remove lazy loading and h5py format encodingmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project are documented here. Newest releases first.
 
+## [v0.3.1] - 2026-06-18
+
+> Package version `0.3.1`. Still not production-ready yet.
+
+### Changed
+- `ImageEncodingMap` now encodes every image up front instead of lazily on first access, which drops the in-memory buffer machinery and simplifies the class.
+- `ImageEncodingMap.save_to_disk()` / `load_from_disk()` now use the safetensors format instead of HDF5. Files default to the `.safetensors` extension.
+- `skip_errors` moved from `save_to_disk()` to the `ImageEncodingMap` constructor, since encoding now happens at construction time.
+
+### Removed
+- Dropped `h5py` as a dependency; added `safetensors`.
+- Removed `ImageEncodingMap.clear_buffer()` (there's no buffer to clear anymore).
+
+### Breaking
+- ⚠️ Unreadable or missing images now raise (`FileNotFoundError` / `ValueError`) when the map is built, not on first access. Use `skip_errors=True` to drop them with a warning instead.
+- ⚠️ Encoding maps saved with `0.3.0` (HDF5) can't be loaded by `0.3.1`; re-save them as safetensors.
+
 ## [v0.3.0] - 2026-06-17
 
 > Package version `0.3.0`. Still not production-ready yet.

--- a/docs/image_store.md
+++ b/docs/image_store.md
@@ -7,12 +7,10 @@ File: [`pyvisim/image_store/__init__.py`](../pyvisim/image_store/__init__.py)
 `Mapping`, so you use it like a dict: index by path, iterate, call `len`, `.values()`,
 `dict(...)`, and so on.
 
-## Lazy, then sticky
+## Encode images
 
-Nothing is encoded up front. The first time you ask for a path, the image is read,
-encoded, and the vector is kept in an in-memory buffer. Ask for the same path again and
-you get the buffered vector back instantly. The buffer is unbounded and never evicts on
-its own, so once a vector is computed it stays put for the lifetime of the object.
+You can encode a batch of images and get a mapping that maps
+each path to its encoding vector (in form `{path: str → encoding: np.ndarray}` with the following code:
 
 ```python
 from pyvisim.encoders import VLADEncoder
@@ -21,12 +19,20 @@ from pyvisim.image_store import ImageEncodingMap
 encoder = VLADEncoder(n_clusters=64)
 encoder.learn(train_images)
 
-store = ImageEncodingMap(encoder, ["a.jpg", "b.jpg", "c.jpg"])
-vec = store["a.jpg"]        # reads + encodes "a.jpg" on this first access
-vec_again = store["a.jpg"]  # served straight from the buffer, no re-encoding
+store = ImageEncodingMap(encoder, ["a.jpg", "b.jpg", "c.jpg"])  # encodes all three now
+vec = store["a.jpg"]  # access the encoding.
 ```
 
-You can also get one straight from an encoder or a pipeline via
+A missing file raises `FileNotFoundError` and a file that isn't a valid image raises
+`ValueError`. If you'd rather skip the bad ones, pass `skip_errors=True` and they're dropped
+with a warning instead:
+
+```python
+store = ImageEncodingMap(encoder, ["a.jpg", "missing.jpg"], skip_errors=True)
+# RuntimeWarning: Skipped 1 image(s) that could not be encoded.
+```
+
+You can also get a map straight from an encoder or a pipeline via
 [`generate_encoding_map`](encoders/base_encoder.md):
 
 ```python
@@ -36,33 +42,14 @@ store = encoder.generate_encoding_map(["a.jpg", "b.jpg", "c.jpg"])
 Any object that satisfies the [`Encoder`](typing.md) protocol works here, so encoders and
 `Pipeline` are both fair game.
 
-## Freeing memory
-
-Holding every encoding in memory is convenient but not free. When you're done with the
-cached vectors, call `clear_buffer()` to drop them. The registered paths stay, so the next
-access just re-encodes lazily.
-
-```python
-store.clear_buffer()  # buffer emptied; paths still known
-store["a.jpg"]         # re-encoded on demand
-```
-
 ## Saving and loading
 
-`save_to_disk(path)` encodes everything (reusing whatever is already buffered) and writes
-the full `path → encoding` mapping to an HDF5 file. `load_from_disk(path, encoder)` rebuilds
-the map with those encodings loaded straight into the buffer, so reopening a saved store
-involves no re-encoding.
+`save_to_disk(path)` writes the `path → encoding` mapping to a
+[safetensors](https://github.com/huggingface/safetensors) file: the stacked encoding matrix
+is stored as a single tensor, and the paths, encoder name, and format version live in the
+file metadata. `load_from_disk(path, encoder)` reads those vectors back.
 
 ```python
-store.save_to_disk("encodings.h5")
-restored = ImageEncodingMap.load_from_disk("encodings.h5", encoder)
+store.save_to_disk("encodings.safetensors")
+restored = ImageEncodingMap.load_from_disk("encodings.safetensors", encoder)
 ```
-
-A few things worth knowing:
-
-- Pass `skip_errors=True` to `save_to_disk` to warn about and skip images that can't be
-  read instead of aborting the whole save.
-- Saving an empty store, or one where every image fails to encode, raises `ValueError`.
-- `load_from_disk` warns if the encoder you pass doesn't match the one recorded in the
-  file, since re-encoding new paths would then disagree with the stored vectors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "h5py",
     "joblib",
     "numpy",
     "opencv-python",
@@ -88,7 +87,6 @@ plugins = ["numpy.typing.mypy_plugin"]
 # Third-party libraries that ship without type stubs or a py.typed marker.
 [[tool.mypy.overrides]]
 module = [
-  "h5py.*",
   "joblib.*",
   "scipy.*",
   "sklearn.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyvisim"
-version = "0.3.0"
+version = "0.3.1"
 description = "A Python library for image similarity analysis using Image Encoders and Neural Networks"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "opencv-python",
     "platformdirs",
     "PyYAML",
+    "safetensors",
     "scikit-learn",
     "scipy",
     "torch",

--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -585,9 +585,8 @@ class ImageEncoderBase(SimilarityMetric):
         """
         Build an :class:`~pyvisim.image_store.ImageEncodingMap` from image paths.
 
-        The returned object is a lazy ``{image_path: encoded_vector}`` mapping:
-        each image is read and encoded on first access and then buffered in
-        memory.
+        The returned object is a ``{image_path: encoded_vector}`` mapping:
+        each image is read and encoded up front.
 
         The result behaves like a regular dictionary: access the encoding for a path
         by simply:

--- a/pyvisim/encoders/pipeline.py
+++ b/pyvisim/encoders/pipeline.py
@@ -95,11 +95,8 @@ class Pipeline(SimilarityMetric):
         """
         Build an :class:`~pyvisim.image_store.ImageEncodingMap` from image paths.
 
-        The returned object is a lazy ``{image_path: encoded_vector}`` mapping:
-        each image is read and encoded with the full pipeline on first access
-        and then buffered in memory. It behaves like the previously returned
-        dictionary (indexing by path, iteration, ``len``, ``values``), so
-        existing path-based access keeps working.
+        The returned object is a ``{image_path: encoded_vector}`` mapping:
+        each image is read and encoded with the full pipeline up front.
 
         :param image_paths: List of image full paths.
         :return: An :class:`~pyvisim.image_store.ImageEncodingMap` mapping each

--- a/pyvisim/image_store/__init__.py
+++ b/pyvisim/image_store/__init__.py
@@ -1,4 +1,4 @@
-"""Persistent, lazily-populated image-path to encoding-vector mappings."""
+"""Image-path to encoding-vector mappings."""
 
 from .image_store import ImageEncodingMap
 

--- a/pyvisim/image_store/image_store.py
+++ b/pyvisim/image_store/image_store.py
@@ -17,11 +17,6 @@ _FORMAT_VERSION = 1
 class ImageEncodingMap(Mapping[str, FloatNumpyArray]):
     """Map an image path to its encoding vector.
 
-    The encoding for a given path is computed lazily on first access. Once a
-    vector has been computed (or loaded) it is kept in an in-memory buffer for
-    the rest of the object's lifetime. Call :meth:`clear_buffer` to release the
-    buffered vectors; they are recomputed lazily on the next access.
-
     The full ``path -> encoding`` mapping can be written to and restored from
     an HDF5 file via :meth:`save_to_disk` and :meth:`load_from_disk`.
 
@@ -29,78 +24,69 @@ class ImageEncodingMap(Mapping[str, FloatNumpyArray]):
         object satisfying :class:`pyvisim.typing.Encoder` is accepted.
     :param image_paths: Iterable of image file paths. Duplicates are dropped,
         keeping the first occurrence. May be ``None`` to start empty.
+    :param skip_errors: If ``True``, images that cannot be read or encoded are
+        skipped with a warning instead of aborting construction.
     :raises TypeError: If any provided path is not a string.
+    :raises FileNotFoundError: If an image file is missing (and
+        ``skip_errors`` is ``False``).
+    :raises ValueError: If an image cannot be decoded (and ``skip_errors`` is
+        ``False``).
     """
 
     def __init__(
         self,
         encoder: Encoder,
         image_paths: Iterable[str] | None = None,
+        *,
+        skip_errors: bool = False,
     ) -> None:
         self.encoder = encoder
-        self._paths: list[str] = []
-        self._known: set[str] = set()
-        self._buffer: dict[str, FloatNumpyArray] = {}
+        self._encodings: dict[str, FloatNumpyArray] = {}
 
         if image_paths is not None:
-            self._register_paths(image_paths)
+            self._encode_paths(image_paths, skip_errors)
 
     def __len__(self) -> int:
-        return len(self._paths)
+        return len(self._encodings)
 
     def __iter__(self) -> Iterator[str]:
-        return iter(self._paths)
+        return iter(self._encodings)
 
     def __contains__(self, key: object) -> bool:
-        return key in self._known
+        return key in self._encodings
 
     def __getitem__(self, key: str) -> FloatNumpyArray:
         if not isinstance(key, str):
             raise KeyError(
                 f"Image key must be a path string, got {type(key).__name__}."
             )
-        if key not in self._known:
+        if key not in self._encodings:
             raise KeyError(f"Unknown image path: {key!r}.")
-
-        if key not in self._buffer:
-            self._buffer[key] = self._encode_path(key)
-        return self._buffer[key]
+        return self._encodings[key]
 
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}(num_images={len(self)}, "
-            f"encoder={self.encoder.__class__.__name__}, "
-            f"buffered={len(self._buffer)})"
+            f"encoder={self.encoder.__class__.__name__})"
         )
 
-    def save_to_disk(self, file_path: str, *, skip_errors: bool = False) -> None:
-        """Encode every image and persist the mapping to an HDF5 file.
+    def save_to_disk(self, file_path: str) -> None:
+        """Persist the ``path -> encoding`` mapping to an HDF5 file.
 
         :param file_path: Destination ``.h5`` path. Overwritten if it exists.
-        :param skip_errors: If ``True``, unreadable images are skipped with a
-            warning instead of aborting the whole save.
-        :raises ValueError: If the store is empty, no image could be encoded,
-            encodings have inconsistent lengths, or (with
-            ``skip_errors=False``) an image fails to encode.
+        :raises ValueError: If the store is empty or the encodings have
+            inconsistent lengths.
         :raises OSError: If the destination directory does not exist.
         """
-        if not self._paths:
+        if not self._encodings:
             raise ValueError("Cannot save an empty ImageStore.")
 
         parent = os.path.dirname(os.path.abspath(file_path))
         if not os.path.isdir(parent):
             raise OSError(f"Destination directory does not exist: {parent!r}.")
 
-        saved_paths, encodings, failures = self._collect_encodings(skip_errors)
-
-        if failures:
-            warnings.warn(
-                f"Skipped {len(failures)} image(s) that could not be encoded.",
-                RuntimeWarning,
-                stacklevel=2,
-            )
-        if not encodings:
-            raise ValueError("No images could be encoded; nothing to save.")
+        saved_paths = list(self._encodings)
+        encodings = [np.asarray(vector) for vector in self._encodings.values()]
         if len({vector.shape[0] for vector in encodings}) != 1:
             raise ValueError("All encodings must share the same length to be saved.")
 
@@ -125,11 +111,12 @@ class ImageEncodingMap(Mapping[str, FloatNumpyArray]):
     ) -> ImageEncodingMap:
         """Rebuild an :class:`ImageEncodingMap` from a :meth:`save_to_disk` file.
 
-        **NOTE**: this loads the encodings straight into the in-memory buffer.
+        The encodings are restored directly from the file; no image is
+        re-encoded.
 
         :param file_path: Path to an HDF5 file produced by :meth:`save_to_disk`.
-        :param encoder: Encoder to attach. Re-encoding (e.g. after adding new
-            paths) relies on it, so it should match the one used when saving.
+        :param encoder: Encoder to attach. It should match the one used when
+            saving.
         :returns: A populated :class:`ImageEncodingMap`.
         :raises FileNotFoundError: If ``file_path`` does not exist.
         :raises ValueError: If the file is missing the required datasets.
@@ -156,30 +143,41 @@ class ImageEncodingMap(Mapping[str, FloatNumpyArray]):
                 stacklevel=2,
             )
 
-        store = cls(encoder, image_paths=paths)
-        for path, vector in zip(paths, encodings, strict=True):
-            store._buffer[path] = np.asarray(vector)
+        store = cls(encoder)
+        store._encodings = {
+            path: np.asarray(vector)
+            for path, vector in zip(paths, encodings, strict=True)
+        }
         return store
 
-    def clear_buffer(self) -> None:
-        """Drop every buffered encoding, freeing the memory they occupy.
+    def _encode_paths(self, image_paths: Iterable[str], skip_errors: bool) -> None:
+        """Encode every path, dropping duplicates and validating their type.
 
-        Registered paths are kept, so subsequent access re-encodes the
-        corresponding images lazily.
+        :param image_paths: Iterable of image file paths to encode.
+        :param skip_errors: If ``True``, unreadable images are skipped with a
+            warning instead of raising.
         """
-        self._buffer.clear()
-
-    def _register_paths(self, image_paths: Iterable[str]) -> None:
-        """Add paths, dropping duplicates and validating their type."""
+        failures: list[str] = []
         for path in image_paths:
             if not isinstance(path, str):
                 raise TypeError(
                     f"Image paths must be strings, got {type(path).__name__}."
                 )
-            if path in self._known:
+            if path in self._encodings:
                 continue
-            self._known.add(path)
-            self._paths.append(path)
+            try:
+                self._encodings[path] = self._encode_path(path)
+            except (FileNotFoundError, ValueError, OSError):
+                if not skip_errors:
+                    raise
+                failures.append(path)
+
+        if failures:
+            warnings.warn(
+                f"Skipped {len(failures)} image(s) that could not be encoded.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
     def _encode_path(self, path: str) -> FloatNumpyArray:
         """Open one image and return its flattened encoding."""
@@ -191,25 +189,3 @@ class ImageEncodingMap(Mapping[str, FloatNumpyArray]):
         except (UnidentifiedImageError, OSError) as exc:
             raise ValueError(f"Could not read image {path!r}: {exc}") from exc
         return self.encoder.encode(rgb_image).flatten()
-
-    def _collect_encodings(
-        self, skip_errors: bool
-    ) -> tuple[list[str], list[FloatNumpyArray], list[str]]:
-        """Encode all registered paths in preparation for saving.
-
-        :returns: A ``(saved_paths, encodings, failures)`` tuple.
-        """
-        saved_paths: list[str] = []
-        encodings: list[FloatNumpyArray] = []
-        failures: list[str] = []
-        for path in self._paths:
-            try:
-                vector = self[path]
-            except (KeyError, ValueError, OSError) as exc:
-                if not skip_errors:
-                    raise ValueError(f"Failed to encode {path!r}: {exc}") from exc
-                failures.append(path)
-                continue
-            saved_paths.append(path)
-            encodings.append(np.asarray(vector))
-        return saved_paths, encodings, failures

--- a/pyvisim/image_store/image_store.py
+++ b/pyvisim/image_store/image_store.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
+import json
 import os
 import warnings
 from collections.abc import Iterable, Iterator, Mapping
 
-import h5py
 import numpy as np
 from PIL import Image, UnidentifiedImageError
+from safetensors import safe_open
+from safetensors.numpy import save_file
 
 from ..typing import Encoder, FloatNumpyArray
 
-#: On-disk format version, bumped if the HDF5 layout ever changes.
+#: Name of the tensor holding the stacked encoding matrix on disk.
+_ENCODINGS_KEY = "encodings"
+#: On-disk format version, bumped if the safetensors layout ever changes.
 _FORMAT_VERSION = 1
 
 
@@ -71,9 +75,13 @@ class ImageEncodingMap(Mapping[str, FloatNumpyArray]):
         )
 
     def save_to_disk(self, file_path: str) -> None:
-        """Persist the ``path -> encoding`` mapping to an HDF5 file.
+        """Persist the ``path -> encoding`` mapping to a safetensors file.
 
-        :param file_path: Destination ``.h5`` path. Overwritten if it exists.
+        The stacked encoding matrix is stored as a single tensor; the image
+        paths, encoder name and format version live in the file metadata.
+
+        :param file_path: Destination ``.safetensors`` path. Overwritten if it
+            exists.
         :raises ValueError: If the store is empty or the encodings have
             inconsistent lengths.
         :raises OSError: If the destination directory does not exist.
@@ -90,18 +98,13 @@ class ImageEncodingMap(Mapping[str, FloatNumpyArray]):
         if len({vector.shape[0] for vector in encodings}) != 1:
             raise ValueError("All encodings must share the same length to be saved.")
 
-        matrix = np.stack(encodings)
-        string_dtype = h5py.string_dtype(encoding="utf-8")
-
-        with h5py.File(file_path, "w") as handle:
-            handle.create_dataset("encodings", data=matrix, compression="gzip")
-            handle.create_dataset(
-                "paths",
-                data=np.array(saved_paths, dtype=object),
-                dtype=string_dtype,
-            )
-            handle.attrs["encoder"] = self.encoder.__class__.__name__
-            handle.attrs["format_version"] = _FORMAT_VERSION
+        matrix = np.ascontiguousarray(np.stack(encodings))
+        metadata = {
+            "paths": json.dumps(saved_paths),
+            "encoder": self.encoder.__class__.__name__,
+            "format_version": str(_FORMAT_VERSION),
+        }
+        save_file({_ENCODINGS_KEY: matrix}, file_path, metadata=metadata)
 
     @classmethod
     def load_from_disk(
@@ -114,26 +117,33 @@ class ImageEncodingMap(Mapping[str, FloatNumpyArray]):
         The encodings are restored directly from the file; no image is
         re-encoded.
 
-        :param file_path: Path to an HDF5 file produced by :meth:`save_to_disk`.
+        :param file_path: Path to a safetensors file produced by
+            :meth:`save_to_disk`.
         :param encoder: Encoder to attach. It should match the one used when
             saving.
         :returns: A populated :class:`ImageEncodingMap`.
         :raises FileNotFoundError: If ``file_path`` does not exist.
-        :raises ValueError: If the file is missing the required datasets.
+        :raises ValueError: If the file is missing the required tensor or
+            metadata.
         """
         if not os.path.exists(file_path):
-            raise FileNotFoundError(f"No such HDF5 file: {file_path!r}.")
+            raise FileNotFoundError(f"No such safetensors file: {file_path!r}.")
 
-        with h5py.File(file_path, "r") as handle:
-            for name in ("encodings", "paths"):
-                if name not in handle:
-                    raise ValueError(
-                        f"{file_path!r} is missing the {name!r} dataset; it "
-                        "was not written by ImageEncodingMap.save_to_disk."
-                    )
-            encodings = handle["encodings"][...]
-            paths = list(handle["paths"].asstr()[...])
-            stored_encoder = handle.attrs.get("encoder")
+        with safe_open(file_path, framework="numpy") as handle:
+            metadata = handle.metadata() or {}
+            if _ENCODINGS_KEY not in handle.keys():
+                raise ValueError(
+                    f"{file_path!r} is missing the {_ENCODINGS_KEY!r} tensor; "
+                    "it was not written by ImageEncodingMap.save_to_disk."
+                )
+            if "paths" not in metadata:
+                raise ValueError(
+                    f"{file_path!r} is missing the 'paths' metadata; it was "
+                    "not written by ImageEncodingMap.save_to_disk."
+                )
+            encodings = handle.get_tensor(_ENCODINGS_KEY)
+            paths = json.loads(metadata["paths"])
+            stored_encoder = metadata.get("encoder")
 
         if stored_encoder and stored_encoder != encoder.__class__.__name__:
             warnings.warn(

--- a/pyvisim/image_store/image_store.py
+++ b/pyvisim/image_store/image_store.py
@@ -22,7 +22,7 @@ class ImageEncodingMap(Mapping[str, FloatNumpyArray]):
     """Map an image path to its encoding vector.
 
     The full ``path -> encoding`` mapping can be written to and restored from
-    an HDF5 file via :meth:`save_to_disk` and :meth:`load_from_disk`.
+    a safetensors file via :meth:`save_to_disk` and :meth:`load_from_disk`.
 
     :param encoder: Encoder used to turn an image into a fixed-size vector. Any
         object satisfying :class:`pyvisim.typing.Encoder` is accepted.

--- a/tests/image_store/test_image_store.py
+++ b/tests/image_store/test_image_store.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import inspect
+import json
 from pathlib import Path
 
-import h5py
 import numpy as np
 import pytest
 from PIL import Image
+from safetensors.numpy import save_file
 
 from pyvisim.encoders import FisherVectorEncoder, VLADEncoder
 from pyvisim.image_store import ImageEncodingMap
@@ -53,79 +54,30 @@ def image_paths(
 
 @pytest.fixture
 def image_map(encoder: VLADEncoder, image_paths: list[str]) -> ImageEncodingMap:
-    """A fresh, unbuffered :class:`ImageEncodingMap` over the test images.
+    """An :class:`ImageEncodingMap` over the test images.
 
     :param encoder: the learned encoder fixture.
     :param image_paths: the on-disk image paths fixture.
-    :returns: an ``ImageEncodingMap`` with no encodings buffered yet.
+    :returns: an ``ImageEncodingMap`` whose encodings are computed up front.
     """
     return ImageEncodingMap(encoder, image_paths)
 
 
-# Lazy, unbounded, permanent buffering
+# encoding
 
 
-def test_buffer_empty_until_first_access(image_map: ImageEncodingMap) -> None:
-    """Construction registers paths but encodes nothing up front."""
-    assert len(image_map) == NUM_IMAGES
-    assert len(image_map._buffer) == 0
-
-
-def test_access_buffers_a_single_vector(
+def test_access_returns_one_dimensional_vector(
     image_map: ImageEncodingMap, image_paths: list[str]
 ) -> None:
-    """Accessing one path encodes and buffers exactly that one path."""
+    """Indexing a path returns its flattened, 1-D encoding vector."""
     vector = image_map[image_paths[0]]
     assert vector.ndim == 1
-    assert set(image_map._buffer) == {image_paths[0]}
-
-
-def test_repeated_access_is_cached(
-    image_map: ImageEncodingMap, image_paths: list[str]
-) -> None:
-    """A second access returns the same buffered object without re-encoding."""
-    first = image_map[image_paths[0]]
-    second = image_map[image_paths[0]]
-    assert first is second
-    assert len(image_map._buffer) == 1
-
-
-def test_buffer_has_no_cap(image_map: ImageEncodingMap, image_paths: list[str]) -> None:
-    """Every accessed encoding stays buffered; nothing is ever evicted."""
-    for path in image_paths:
-        image_map[path]
-    assert len(image_map._buffer) == NUM_IMAGES
 
 
 def test_constructor_has_no_cache_size_parameter() -> None:
     """The removed buffer cap must not reappear on the constructor."""
     params = inspect.signature(ImageEncodingMap.__init__).parameters
     assert "max_cache_size" not in params
-
-
-# Clearing the buffer
-
-
-def test_clear_buffer_empties_buffer_but_keeps_paths(
-    image_map: ImageEncodingMap, image_paths: list[str]
-) -> None:
-    """``clear_buffer`` drops buffered vectors while keeping registered paths."""
-    for path in image_paths:
-        image_map[path]
-    image_map.clear_buffer()
-    assert len(image_map._buffer) == 0
-    assert len(image_map) == NUM_IMAGES
-
-
-def test_reaccess_after_clear_recomputes(
-    image_map: ImageEncodingMap, image_paths: list[str]
-) -> None:
-    """After clearing, accessing a path re-encodes and re-buffers it."""
-    original = image_map[image_paths[0]]
-    image_map.clear_buffer()
-    recomputed = image_map[image_paths[0]]
-    assert np.allclose(original, recomputed)
-    assert len(image_map._buffer) == 1
 
 
 # Mapping protocol
@@ -147,13 +99,12 @@ def test_dict_conversion_round_trips_keys(
     assert all(vector.ndim == 1 for vector in as_dict.values())
 
 
-def test_contains_does_not_trigger_encoding(
+def test_contains_reports_registered_paths(
     image_map: ImageEncodingMap, image_paths: list[str]
 ) -> None:
-    """Membership tests are cheap and never encode anything."""
+    """Membership tests report whether a path was registered."""
     assert image_paths[0] in image_map
     assert "not-a-registered-path" not in image_map
-    assert len(image_map._buffer) == 0
 
 
 # Path registration and key validation
@@ -200,22 +151,30 @@ def test_empty_map_has_no_paths(encoder: VLADEncoder) -> None:
 def test_missing_file_raises_file_not_found(
     encoder: VLADEncoder, tmp_path: Path
 ) -> None:
-    """Accessing a registered-but-missing file raises ``FileNotFoundError``."""
+    """A registered-but-missing file raises ``FileNotFoundError`` on construction."""
     missing = str(tmp_path / "gone.png")
-    store = ImageEncodingMap(encoder, [missing])
     with pytest.raises(FileNotFoundError):
-        store[missing]
+        ImageEncodingMap(encoder, [missing])
 
 
 def test_unreadable_file_raises_value_error(
     encoder: VLADEncoder, tmp_path: Path
 ) -> None:
-    """A registered file that is not an image raises ``ValueError``."""
+    """A registered file that is not an image raises ``ValueError`` on construction."""
     bogus = tmp_path / "bogus.png"
     bogus.write_text("this is not an image")
-    store = ImageEncodingMap(encoder, [str(bogus)])
     with pytest.raises(ValueError, match="Could not read image"):
-        store[str(bogus)]
+        ImageEncodingMap(encoder, [str(bogus)])
+
+
+def test_skip_errors_warns_and_keeps_good_images(
+    encoder: VLADEncoder, image_paths: list[str], tmp_path: Path
+) -> None:
+    """``skip_errors`` warns about and omits images that fail to encode."""
+    missing = str(tmp_path / "missing.png")
+    with pytest.warns(RuntimeWarning, match="Skipped 1 image"):
+        store = ImageEncodingMap(encoder, [image_paths[0], missing], skip_errors=True)
+    assert set(store) == {image_paths[0]}
 
 
 # Persistence: save_to_disk / load_from_disk
@@ -224,15 +183,14 @@ def test_unreadable_file_raises_value_error(
 def test_save_and_load_round_trip(
     image_map: ImageEncodingMap, encoder: VLADEncoder, tmp_path: Path
 ) -> None:
-    """A saved store reloads with identical, pre-buffered encodings."""
+    """A saved store reloads with identical encodings."""
     expected = {path: image_map[path] for path in image_map}
-    target = str(tmp_path / "store.h5")
+    target = str(tmp_path / "store.safetensors")
     image_map.save_to_disk(target)
 
     loaded = ImageEncodingMap.load_from_disk(target, encoder)
     assert set(loaded) == set(image_map)
-    # Loaded encodings live in the buffer, so no re-encoding is required.
-    assert len(loaded._buffer) == len(loaded)
+    assert len(loaded._encodings) == len(loaded)
     for path, vector in expected.items():
         assert np.allclose(loaded[path], vector)
 
@@ -241,43 +199,40 @@ def test_save_empty_store_raises(encoder: VLADEncoder, tmp_path: Path) -> None:
     """Saving a store with no images raises ``ValueError``."""
     store = ImageEncodingMap(encoder)
     with pytest.raises(ValueError, match="empty ImageStore"):
-        store.save_to_disk(str(tmp_path / "empty.h5"))
+        store.save_to_disk(str(tmp_path / "empty.safetensors"))
 
 
 def test_save_to_missing_directory_raises(image_map: ImageEncodingMap) -> None:
     """Saving into a non-existent directory raises ``OSError``."""
     with pytest.raises(OSError, match="directory does not exist"):
-        image_map.save_to_disk("/no/such/directory/store.h5")
-
-
-def test_save_skip_errors_warns_and_persists_good_images(
-    encoder: VLADEncoder, image_paths: list[str], tmp_path: Path
-) -> None:
-    """``skip_errors`` warns about and omits images that fail to encode."""
-    missing = str(tmp_path / "missing.png")
-    store = ImageEncodingMap(encoder, [image_paths[0], missing])
-    target = str(tmp_path / "partial.h5")
-    with pytest.warns(RuntimeWarning, match="Skipped 1 image"):
-        store.save_to_disk(target, skip_errors=True)
-
-    reloaded = ImageEncodingMap.load_from_disk(target, encoder)
-    assert set(reloaded) == {image_paths[0]}
+        image_map.save_to_disk("/no/such/directory/store.safetensors")
 
 
 def test_load_missing_file_raises(encoder: VLADEncoder, tmp_path: Path) -> None:
     """Loading a path that does not exist raises ``FileNotFoundError``."""
-    with pytest.raises(FileNotFoundError, match="No such HDF5 file"):
-        ImageEncodingMap.load_from_disk(str(tmp_path / "absent.h5"), encoder)
+    with pytest.raises(FileNotFoundError, match="No such safetensors file"):
+        ImageEncodingMap.load_from_disk(str(tmp_path / "absent.safetensors"), encoder)
 
 
-def test_load_file_missing_datasets_raises(
+def test_load_file_missing_tensor_raises(encoder: VLADEncoder, tmp_path: Path) -> None:
+    """Loading a safetensors file without the encodings tensor raises ``ValueError``."""
+    target = tmp_path / "wrong.safetensors"
+    save_file(
+        {"unrelated": np.zeros(3, dtype=np.float32)},
+        str(target),
+        metadata={"paths": json.dumps([])},
+    )
+    with pytest.raises(ValueError, match="missing the 'encodings' tensor"):
+        ImageEncodingMap.load_from_disk(str(target), encoder)
+
+
+def test_load_file_missing_paths_metadata_raises(
     encoder: VLADEncoder, tmp_path: Path
 ) -> None:
-    """Loading an HDF5 file without the expected datasets raises ``ValueError``."""
-    target = tmp_path / "wrong.h5"
-    with h5py.File(target, "w") as handle:
-        handle.create_dataset("unrelated", data=np.zeros(3))
-    with pytest.raises(ValueError, match="missing the"):
+    """Loading a safetensors file without the paths metadata raises ``ValueError``."""
+    target = tmp_path / "no_paths.safetensors"
+    save_file({"encodings": np.zeros((1, 3), dtype=np.float32)}, str(target))
+    with pytest.raises(ValueError, match="missing the 'paths' metadata"):
         ImageEncodingMap.load_from_disk(str(target), encoder)
 
 
@@ -288,7 +243,7 @@ def test_load_with_mismatched_encoder_warns(
     tmp_path: Path,
 ) -> None:
     """Loading with a different encoder class warns about the mismatch."""
-    target = str(tmp_path / "store.h5")
+    target = str(tmp_path / "store.safetensors")
     image_map.save_to_disk(target)
 
     other = FisherVectorEncoder(n_components=4, gmm_params={"random_state": 0})


### PR DESCRIPTION
### Related Issues

- fixes #

### Proposed Changes:

This turns `generate_encoding_map` into something more useful than a plain dict, and reorganizes `pyvisim.typing` to support it cleanly.

The headline change is `ImageEncodingMap` (new `pyvisim.image_store` package). It's a read-only `Mapping` from image path to encoding vector that encodes lazily: nothing happens until you actually index a path, and once a vector is computed it stays buffered in memory for the life of the object. The buffer is unbounded now — I dropped the old `max_cache_size`/LRU eviction, since the whole point is to avoid re-encoding the same images. If you do want the memory back, call `clear_buffer()` and the paths stay registered so they just re-encode on next access. The map also persists to/from HDF5 via `save_to_disk`/`load_from_disk`.

`ImageEncoderBase.generate_encoding_map` and `Pipeline.generate_encoding_map` now return one of these instead of eagerly building a dict. Because `ImageEncodingMap` is a `Mapping`, existing code that accesses encodings by path (indexing, iteration, `len`, `.values()`, `dict(...)`) keeps working unchanged — the only difference is that encoding is deferred to first access.

To wire this up without an import cycle, I split the typing module:
- `pyvisim/typing/_typing.py` → `pyvisim/typing/numeric.py` (numeric types + image normalization helpers).
- New `pyvisim/typing/encoders.py` defines an `Encoder` `Protocol` (just needs an `encode` method). `ImageEncodingMap` depends on this structural type instead of importing the concrete encoder classes, so `image_store` doesn't have to reach back into `encoders`. The public `pyvisim.typing` API is unchanged otherwise; everything is still re-exported.

While moving the encoding code over I also fixed a latent bug: the original draft passed a PIL image straight into `encode`, which `iter_images` rejects (PIL images aren't `Iterable`). It now converts to an ndarray first.

### How did you test it?

- New `tests/image_store/test_image_store.py` (20 tests) covering lazy/unbounded buffering, `clear_buffer`, the `Mapping` protocol, path dedup/validation, encoding-error propagation (missing file, non-image file), and HDF5 save/load round-trips (including `skip_errors`, missing datasets, and encoder-mismatch warnings).
- Updated the existing `generate_encoding_map` tests for the base encoder and the pipeline to assert an `ImageEncodingMap` is returned, while keeping the original path-based access checks.
- Full suite green: `make test-unit` → 223 passed, `make test-types` → mypy clean, and ruff check/format pass on all touched files.

### Notes for the reviewer

- The interesting file is `pyvisim/image_store/image_store.py` — specifically `__getitem__`/`_encode_path` (lazy buffering) and the save/load round-trip.
- Backward compatibility is the main thing I'd want a second pair of eyes on. The return type changed from `dict` to `ImageEncodingMap`, so anything doing `isinstance(result, dict)` would break, but anything using the mapping interface won't. I treated "access by image path" as the contract to preserve, per the requirement.
- `h5py` was added to the mypy missing-stubs overrides (it ships no stubs); it was already a declared dependency.
- Not in this PR's core work: `docs/encoders/pipeline.md` had a stale note claiming `encode` duplicates input with `itertools.tee` (the source uses `iter_images`). I removed that outdated line in a follow-up doc commit on this branch.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md).
- [ ] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] When applicable: I have reviewed the AI-generated code sections, according to [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#using-ai-to-contribute).
- [x] I have run [pre-commit hooks](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#set-up-developer-environment) and fixed any issue.
