### PR TITLE
feat: accept backbone arg on DeepConvFeature, deprecate model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project are documented here. Newest releases first.
 
+## [v0.4.1] - 2026-06-18
+
+> Package version `0.4.1`. Still not production-ready yet.
+
+### Added
+- `DeepConvFeature` now takes a `backbone` argument. Pass `"vgg16"` to grab a
+  torchvision VGG16 with ImageNet weights, or hand it your own `torch.nn.Module`.
+  Leave it out and you still get the default VGG16.
+
+### Deprecated
+- The `model` argument of `DeepConvFeature` is deprecated; use `backbone`
+  instead. If you still pass `model`, it's used as the backbone and you'll get a
+  `DeprecationWarning`. It'll be removed in a future release.
+
 ## [v0.4.0] - 2026-06-18
 
 > Package version `0.4.0`. Still not production-ready yet.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyvisim"
-version = "0.4.0"
+version = "0.4.1"
 description = "A Python library for image similarity analysis using Image Encoders and Neural Networks"
 readme = "README.md"
 license = "MIT"

--- a/pyvisim/features/_features.py
+++ b/pyvisim/features/_features.py
@@ -6,6 +6,7 @@ custom feature extraction functions, and deep convolutional feature extraction
 with optional spatial encoding.
 """
 
+import warnings
 from collections.abc import Callable
 from functools import wraps
 from typing import Any, TypeVar, cast
@@ -303,8 +304,15 @@ class DeepConvFeature(FeatureExtractorBase):
     presented in [1], where VLAD encodings were computed from deep convolutional features and input into
     a metric learning algorithm in order to distinguish between different people.
 
-    :param model: A PyTorch model instance from torchvision.model_files. Default is VGG16. In the paper [1],
-                a VGG-Face model trained on Idmb-Wiki dataset was used with VLAD encoding for younger faces verification.
+    :param backbone: The convolutional backbone to extract features from. It may be:
+
+        * ``None`` (default): builds a torchvision VGG16 with ImageNet weights.
+        * A string naming a built-in backbone. Currently only ``"vgg16"`` is
+          supported, which builds a torchvision VGG16 with ImageNet weights.
+        * A ``torch.nn.Module`` instance: any user-supplied PyTorch model.
+
+        In the paper [1], a VGG-Face model trained on the Imdb-Wiki dataset was
+        used with VLAD encoding for younger faces verification.
     :param target_submodule: Optional submodule name to hook into. If None, the whole model is used.
     :param layer_index: Which conv layer to hook (int). Use `list_conv_layers(...)`
                        to see the ordering or use -1 for the last conv layer.
@@ -312,6 +320,12 @@ class DeepConvFeature(FeatureExtractorBase):
     :param device: 'cpu' or 'cuda'. Where to run the model.
     :param transform: Optional torchvision.transforms.Compose. Default includes `to_tensor`, `resize(224, 224)`,
                         and normalization with ImageNet stats.
+
+    .. deprecated:: 0.4.1
+        The ``model`` keyword argument is deprecated; pass the model through
+        ``backbone`` instead. When ``model`` is supplied it is used as the
+        ``backbone`` (unless ``backbone`` is also given) and a
+        :class:`DeprecationWarning` is emitted.
 
     References:
     ===========
@@ -322,20 +336,21 @@ class DeepConvFeature(FeatureExtractorBase):
 
     def __init__(
         self,
-        model: torch.nn.Module | None = None,
+        backbone: str | torch.nn.Module | None = None,
         target_submodule: str | None = None,
         layer_index: int = -1,
         spatial_encoding: bool = True,
         device: str = "cuda" if torch.cuda.is_available() else "cpu",
         transform: transforms.Compose = None,
+        **kwargs: Any,
     ):
         super().__init__()
-        # Track whether the default model is used: when serialising, a default
-        # model is rebuilt from torchvision on load (no weights stored), while a
-        # user-supplied model has its state_dict embedded in the encoder file.
-        self._is_default_model = model is None
-        if model is None:
-            model = vgg16(weights=VGG16_Weights.DEFAULT)
+        backbone = self._resolve_deprecated_model(backbone, kwargs)
+        # Track whether a rebuildable (torchvision-default) model is used: when
+        # serialising, such a model is rebuilt from torchvision on load (no
+        # weights stored), while a user-supplied model has its state_dict
+        # embedded in the encoder file.
+        model, self._is_default_model = _build_backbone(backbone)
         self._model: torch.nn.Module
         self._target_submodule = target_submodule
         self.layer_index = layer_index
@@ -379,6 +394,40 @@ class DeepConvFeature(FeatureExtractorBase):
             else self.selected_layer_module.out_channels
         )
         self._register_hook()
+
+    @staticmethod
+    def _resolve_deprecated_model(
+        backbone: str | torch.nn.Module | None,
+        kwargs: dict[str, Any],
+    ) -> str | torch.nn.Module | None:
+        """
+        Resolve the deprecated ``model`` keyword argument into ``backbone``.
+
+        If ``model`` is present in ``kwargs`` a :class:`DeprecationWarning` is
+        emitted. The popped ``model`` is used as the ``backbone`` only when no
+        explicit ``backbone`` was supplied; otherwise ``backbone`` wins.
+
+        :param backbone: The ``backbone`` argument as passed by the caller.
+        :param kwargs: Extra keyword arguments captured by ``__init__``.
+        :return: The backbone to use.
+        :raises TypeError: If ``kwargs`` contains unexpected keyword arguments.
+        """
+        if "model" in kwargs:
+            warnings.warn(
+                "The 'model' argument of DeepConvFeature is deprecated and will "
+                "be removed in a future release; pass the model through "
+                "'backbone' instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            model = kwargs.pop("model")
+            if backbone is None:
+                backbone = model
+        if kwargs:
+            raise TypeError(
+                f"DeepConvFeature got unexpected keyword arguments: {sorted(kwargs)}."
+            )
+        return backbone
 
     @property
     def output_dim(self) -> int:
@@ -561,22 +610,63 @@ class DeepConvFeature(FeatureExtractorBase):
 
     def __repr__(self) -> str:
         return (
-            f"DeepConvFeature(model={type(self.model).__name__}, layer_index={self.layer_index}, "
+            f"DeepConvFeature(backbone={type(self.model).__name__}, layer_index={self.layer_index}, "
             f"spatial_encoding={self.spatial_encoding}, device={self.device}, "
             f"transform={self.transform}, selected_layer_name={self.selected_layer_name}, "
             f"selected_layer_module={self.selected_layer_module}, output_dim={self.output_dim})"
         )
 
 
-#: Maps a torchvision model architecture name to a builder. The builder takes a
-#: ``pretrained`` flag: ``True`` loads torchvision's default (ImageNet) weights,
-#: ``False`` returns the bare architecture so embedded weights can be loaded into
-#: it. Used to rebuild :class:`DeepConvFeature` extractors when loading an encoder.
-_TORCHVISION_MODEL_BUILDERS: dict[str, Callable[[bool], torch.nn.Module]] = {
-    "VGG": lambda pretrained: vgg16(
+#: Maps a backbone identifier to a builder. The builder takes a ``pretrained``
+#: flag: ``True`` loads torchvision's default (ImageNet) weights, ``False``
+#: returns the bare architecture so embedded weights can be loaded into it.
+#:
+#: Each backbone is registered under two identifiers so a single map serves both
+#: lookups: the friendly name users pass via ``backbone`` (e.g. ``"vgg16"``) and
+#: the model class name serialization recovers from a model instance
+#: (``type(model).__name__``, e.g. ``"VGG"``). Currently only VGG16 is supported.
+_BACKBONE_BUILDERS: dict[str, Callable[[bool], torch.nn.Module]] = {
+    "vgg16": lambda pretrained: vgg16(
         weights=VGG16_Weights.DEFAULT if pretrained else None
     ),
 }
+_BACKBONE_BUILDERS["VGG"] = _BACKBONE_BUILDERS["vgg16"]
+
+
+def _build_backbone(
+    backbone: str | torch.nn.Module | None,
+) -> tuple[torch.nn.Module, bool]:
+    """
+    Resolve a ``backbone`` argument into a concrete model.
+
+    :param backbone: ``None`` for the default VGG16, a string naming a built-in
+        backbone (see :data:`_BACKBONE_BUILDERS`), or a ``torch.nn.Module``.
+    :return: A ``(model, is_default_model)`` tuple. ``is_default_model`` is
+        ``True`` when the model can be rebuilt from torchvision's default
+        weights on load (``None`` or a built-in name) and ``False`` for a
+        user-supplied module whose weights must be embedded when serialising.
+    :raises ValueError: If ``backbone`` is an unknown built-in name.
+    :raises TypeError: If ``backbone`` is neither ``None``, a string, nor a
+        ``torch.nn.Module``.
+    """
+    if backbone is None:
+        return _BACKBONE_BUILDERS["vgg16"](True), True
+    if isinstance(backbone, str):
+        builder = _BACKBONE_BUILDERS.get(backbone.lower())
+        if builder is None:
+            # Only the friendly, lowercase names are public; the class-name
+            # aliases exist purely for serialization round-trips.
+            raise ValueError(
+                f"Unknown backbone {backbone!r}. Supported backbones: "
+                f"{sorted(name for name in _BACKBONE_BUILDERS if name.islower())}."
+            )
+        return builder(True), True
+    if isinstance(backbone, torch.nn.Module):
+        return backbone, False
+    raise TypeError(
+        "backbone must be None, a string naming a built-in backbone, or a "
+        f"torch.nn.Module. Got {type(backbone)} instead."
+    )
 
 
 def _build_torchvision_model(arch: str, *, pretrained: bool) -> torch.nn.Module:
@@ -588,7 +678,7 @@ def _build_torchvision_model(arch: str, *, pretrained: bool) -> torch.nn.Module:
     :return: The reconstructed model.
     :raises ValueError: If the architecture is not known.
     """
-    builder = _TORCHVISION_MODEL_BUILDERS.get(arch)
+    builder = _BACKBONE_BUILDERS.get(arch)
     if builder is None:
         raise ValueError(
             f"Cannot automatically rebuild model architecture {arch!r}. "

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -285,10 +285,39 @@ def test_deepconv_bad_submodule_raises() -> None:
         )
 
 
-def test_deepconv_non_module_model_raises() -> None:
-    """A model that is not a ``torch.nn.Module`` raises ``TypeError``."""
+def test_deepconv_invalid_backbone_type_raises() -> None:
+    """A backbone that is neither a string nor a ``torch.nn.Module`` raises ``TypeError``."""
     with pytest.raises(TypeError):
-        DeepConvFeature(model="not a module", device="cpu")  # type: ignore[arg-type]
+        DeepConvFeature(backbone=123, device="cpu")  # type: ignore[arg-type]
+
+
+def test_deepconv_unknown_backbone_name_raises() -> None:
+    """An unknown built-in backbone name raises ``ValueError``."""
+    with pytest.raises(ValueError, match="Unknown backbone"):
+        DeepConvFeature(backbone="not a module", device="cpu")
+
+
+def test_deepconv_deprecated_model_kwarg_warns() -> None:
+    """The deprecated ``model`` keyword still works but emits a ``DeprecationWarning``."""
+    with pytest.warns(DeprecationWarning, match="'model' argument"):
+        extractor = DeepConvFeature(model=_tiny_conv_model(), device="cpu")
+    assert extractor.output_dim == 12
+
+
+def test_deepconv_explicit_backbone_wins_over_deprecated_model() -> None:
+    """When both ``backbone`` and ``model`` are passed, ``backbone`` is used."""
+    backbone = _tiny_conv_model()
+    with pytest.warns(DeprecationWarning):
+        extractor = DeepConvFeature(
+            backbone=backbone, model=nn.Sequential(nn.ReLU()), device="cpu"
+        )
+    assert extractor.model is backbone
+
+
+def test_deepconv_unexpected_kwarg_raises() -> None:
+    """An unexpected keyword argument raises ``TypeError``."""
+    with pytest.raises(TypeError, match="unexpected keyword arguments"):
+        DeepConvFeature(_tiny_conv_model(), bogus=1, device="cpu")  # type: ignore[call-arg]
 
 
 def test_deepconv_accepts_tensor() -> None:
@@ -302,4 +331,12 @@ def test_deepconv_accepts_tensor() -> None:
 def test_deepconv_default_vgg16() -> None:
     """The default VGG16 last conv layer gives ``output_dim == 514`` (512 + 2)."""
     extractor = DeepConvFeature(device="cpu")
+    assert extractor.output_dim == 514
+
+
+@pytest.mark.slow
+def test_deepconv_string_backbone_vgg16() -> None:
+    """The ``"vgg16"`` string backbone builds the same VGG16 extractor."""
+    extractor = DeepConvFeature(backbone="vgg16", device="cpu")
+    assert type(extractor.model).__name__ == "VGG"
     assert extractor.output_dim == 514


### PR DESCRIPTION
### Related Issues

- fixes
- 
### Proposed Changes:

`DeepConvFeature` now takes a `backbone` argument instead of `model`. You can hand it three things:

- nothing at all → you get the default torchvision VGG16 with ImageNet weights (same as before)
- the string `"vgg16"` → builds that same VGG16 for you, so you don't have to import torchvision yourself
- your own `torch.nn.Module` → works exactly like the old `model` argument did

The string path goes through a small `_BACKBONE_BUILDERS` registry, so adding more named backbones later (the roadmap mentions vision transformers) is just a new entry in that dict. Right now `"vgg16"` is the only built-in name; an unknown name raises `ValueError` and lists what's supported.

`model` is now deprecated rather than removed. If you still pass it, it's treated as the `backbone` and you get a `DeprecationWarning`. If you pass both `backbone` and `model`, `backbone` wins (you still get the warning). Any other unexpected keyword now raises a clear `TypeError` instead of being silently swallowed.

I also bumped the version to `0.4.1` and added a changelog entry. The serialization story is unchanged: a `None`/string backbone is flagged as rebuildable (no weights stored, rebuilt from torchvision on load), while a user-supplied module still has its `state_dict` embedded.

### How did you test it?

New and updated unit tests in `tests/features/test_features.py`:

- the deprecated `model=` kwarg still works and emits a `DeprecationWarning`
- `backbone` wins when both `backbone` and `model` are passed
- an invalid backbone type (e.g. an int) raises `TypeError`
- an unknown backbone name raises `ValueError`
- an unexpected keyword raises `TypeError`
- (slow) `backbone="vgg16"` builds a VGG with `output_dim == 514`

`make test-types` and `make test-unit` pass (229 passed, 2 slow deselected). `ruff format`/`check` are clean on the changed files.

### Notes for the reviewer

- The deprecation message is emitted via `warnings.warn(..., DeprecationWarning)` rather than `print`, which is the idiomatic way to surface this and lets callers filter it. Shout if you'd prefer a plain print.
- The old `model="not a module"` test was retired: strings are now valid backbone names, so that case lives on as the `ValueError` "unknown backbone name" test, and the `TypeError` path is now covered by passing a non-module, non-string value instead.
- The only lint failures from `make fmt` are in the untracked `examples/kmeans_comparison.ipynb` notebook, unrelated to this change.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md).
- [ ] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] When applicable: I have reviewed the AI-generated code sections, according to [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#using-ai-to-contribute).
- [x] I have run [pre-commit hooks](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#set-up-developer-environment) and fixed any issue.
