### PR TITLE
fix: replace DeprecationWarning with FutureWarning

### DIFF
--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -255,7 +255,7 @@ class ImageEncoderBase(SimilarityMetric):
             "Loading pretrained models via KMeansWeights/GMMWeights is "
             "deprecated and will be removed in a future release. Use "
             "from_pretrained()/load_from_disk() with .encoder files instead.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=3,
         )
         if "PCA" in weights.name:

--- a/pyvisim/features/_features.py
+++ b/pyvisim/features/_features.py
@@ -325,7 +325,7 @@ class DeepConvFeature(FeatureExtractorBase):
         The ``model`` keyword argument is deprecated; pass the model through
         ``backbone`` instead. When ``model`` is supplied it is used as the
         ``backbone`` (unless ``backbone`` is also given) and a
-        :class:`DeprecationWarning` is emitted.
+        :class:`FutureWarning` is emitted.
 
     References:
     ===========
@@ -403,7 +403,7 @@ class DeepConvFeature(FeatureExtractorBase):
         """
         Resolve the deprecated ``model`` keyword argument into ``backbone``.
 
-        If ``model`` is present in ``kwargs`` a :class:`DeprecationWarning` is
+        If ``model`` is present in ``kwargs`` a :class:`FutureWarning` is
         emitted. The popped ``model`` is used as the ``backbone`` only when no
         explicit ``backbone`` was supplied; otherwise ``backbone`` wins.
 
@@ -417,7 +417,7 @@ class DeepConvFeature(FeatureExtractorBase):
                 "The 'model' argument of DeepConvFeature is deprecated and will "
                 "be removed in a future release; pass the model through "
                 "'backbone' instead.",
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=3,
             )
             model = kwargs.pop("model")

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -298,8 +298,8 @@ def test_deepconv_unknown_backbone_name_raises() -> None:
 
 
 def test_deepconv_deprecated_model_kwarg_warns() -> None:
-    """The deprecated ``model`` keyword still works but emits a ``DeprecationWarning``."""
-    with pytest.warns(DeprecationWarning, match="'model' argument"):
+    """The deprecated ``model`` keyword still works but emits a ``FutureWarning``."""
+    with pytest.warns(FutureWarning, match="'model' argument"):
         extractor = DeepConvFeature(model=_tiny_conv_model(), device="cpu")
     assert extractor.output_dim == 12
 
@@ -307,7 +307,7 @@ def test_deepconv_deprecated_model_kwarg_warns() -> None:
 def test_deepconv_explicit_backbone_wins_over_deprecated_model() -> None:
     """When both ``backbone`` and ``model`` are passed, ``backbone`` is used."""
     backbone = _tiny_conv_model()
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(FutureWarning):
         extractor = DeepConvFeature(
             backbone=backbone, model=nn.Sequential(nn.ReLU()), device="cpu"
         )


### PR DESCRIPTION
replaced "deprecationwarning" with userwarning (sometimes, DeprecationWarning was not propagated to user)