### PR TITLE
bumped version in pyproj to 0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyvisim"
-version = "0.4.1"
+version = "0.4.2"
 description = "A Python library for image similarity analysis using Image Encoders and Neural Networks"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
FutureWarning is shown to end users by default (DeprecationWarning is
silenced unless running tests or developer mode), so this ensures
callers actually see the deprecation notices.