### PR TITLE
Bugfix/decoupling encoder from map

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy",
+    "Pillow",
     "opencv-python",
     "platformdirs",
     "PyYAML",

--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -7,6 +7,7 @@ from functools import wraps
 from typing import Any, ClassVar, TypeVar, cast
 
 import numpy as np
+from PIL import Image, UnidentifiedImageError
 from sklearn.exceptions import NotFittedError
 
 from .._base_classes import FeatureExtractorBase, SimilarityMetric
@@ -542,13 +543,17 @@ class ImageEncoderBase(SimilarityMetric):
         return encoder
 
     @_tupleize_first_arg
-    def generate_encoding_map(self, image_paths: Iterable[str], /) -> ImageEncodingMap:
+    def generate_encoding_map(
+        self,
+        image_paths: Iterable[str],
+        /,
+        *,
+        skip_errors: bool = False,
+    ) -> ImageEncodingMap:
         """
         Build an :class:`~pyvisim.image_store.ImageEncodingMap` from image paths.
 
-        The returned object is a ``{image_path: encoded_vector}`` mapping:
-        each image is read and encoded up front.
-
+        The returned object is a ``{image_path: encoded_vector}`` mapping.
         The result behaves like a regular dictionary: access the encoding for a path
         by simply:
 
@@ -557,11 +562,76 @@ class ImageEncoderBase(SimilarityMetric):
         encoding = encoding_map[image_path]
         ```
 
-        :param image_paths: List of image full paths.
+        :param image_paths: Iterable of image file paths. Duplicates are
+            dropped, keeping the first occurrence.
+        :param skip_errors: If ``True``, images that cannot be read or encoded
+            are skipped with a warning instead of aborting.
         :return: An :class:`~pyvisim.image_store.ImageEncodingMap` mapping each
                 image path to the descriptor vector of the corresponding image.
+        :raises TypeError: If any provided path is not a string.
+        :raises FileNotFoundError: If an image file is missing (and
+            ``skip_errors`` is ``False``).
+        :raises ValueError: If an image cannot be decoded (and ``skip_errors``
+            is ``False``).
         """
-        return ImageEncodingMap(self, image_paths)
+        encodings = self._encode_paths(image_paths, skip_errors)
+        return ImageEncodingMap(encodings)
+
+    def _encode_paths(
+        self,
+        image_paths: Iterable[str],
+        skip_errors: bool,
+    ) -> dict[str, FloatNumpyArray]:
+        """
+        Encode every path, dropping duplicates and validating their type.
+
+        :param image_paths: Iterable of image file paths to encode.
+        :param skip_errors: If ``True``, unreadable images are skipped with a
+            warning instead of raising.
+        :return: A ``{image_path: encoding}`` dictionary in input order.
+        :raises TypeError: If any provided path is not a string.
+        """
+        encodings: dict[str, FloatNumpyArray] = {}
+        failures: list[str] = []
+        for path in image_paths:
+            if not isinstance(path, str):
+                raise TypeError(
+                    f"Image paths must be strings, got {type(path).__name__}."
+                )
+            if path in encodings:
+                continue
+            try:
+                encodings[path] = self._encode_path(path)
+            except (FileNotFoundError, ValueError, OSError):
+                if not skip_errors:
+                    raise
+                failures.append(path)
+
+        if failures:
+            warnings.warn(
+                f"Skipped {len(failures)} image(s) that could not be encoded.",
+                FutureWarning,
+                stacklevel=3,
+            )
+        return encodings
+
+    def _encode_path(self, path: str) -> FloatNumpyArray:
+        """
+        Open one image and return its flattened encoding.
+
+        :param path: Filesystem path of the image to encode.
+        :return: The flattened encoding vector for the image.
+        :raises FileNotFoundError: If the image file is missing.
+        :raises ValueError: If the image cannot be decoded.
+        """
+        try:
+            with Image.open(path) as image:
+                rgb_image = np.asarray(image.convert("RGB"))
+        except FileNotFoundError:
+            raise  # already clear and specific; let it propagate
+        except (UnidentifiedImageError, OSError) as exc:
+            raise ValueError(f"Could not read image {path!r}: {exc}") from exc
+        return self.encode(rgb_image).flatten()
 
     @abc.abstractmethod
     def encode(

--- a/pyvisim/encoders/pipeline.py
+++ b/pyvisim/encoders/pipeline.py
@@ -1,7 +1,9 @@
 import logging
+import warnings
 from collections.abc import Iterable
 
 import numpy as np
+from PIL import Image, UnidentifiedImageError
 
 from .._base_classes import SimilarityMetric
 from .._utils import get_similarity_func
@@ -91,18 +93,90 @@ class Pipeline(SimilarityMetric):
             metric.flatten = a
         return np.hstack(all_encodings)
 
-    def generate_encoding_map(self, image_paths: Iterable[str]) -> ImageEncodingMap:
+    def generate_encoding_map(
+        self,
+        image_paths: Iterable[str],
+        *,
+        skip_errors: bool = False,
+    ) -> ImageEncodingMap:
         """
         Build an :class:`~pyvisim.image_store.ImageEncodingMap` from image paths.
 
-        The returned object is a ``{image_path: encoded_vector}`` mapping:
-        each image is read and encoded with the full pipeline up front.
+        Each image is read and encoded with the full pipeline up front, and the
+        resulting ``{image_path: encoded_vector}`` mapping is wrapped in an
+        :class:`~pyvisim.image_store.ImageEncodingMap`. The map only stores the
+        vectors, so it stays decoupled from the pipeline.
 
-        :param image_paths: List of image full paths.
+        :param image_paths: Iterable of image file paths. Duplicates are
+            dropped, keeping the first occurrence.
+        :param skip_errors: If ``True``, images that cannot be read or encoded
+            are skipped with a warning instead of aborting.
         :return: An :class:`~pyvisim.image_store.ImageEncodingMap` mapping each
                 image path to the descriptor vector of the corresponding image.
+        :raises TypeError: If any provided path is not a string.
+        :raises FileNotFoundError: If an image file is missing (and
+            ``skip_errors`` is ``False``).
+        :raises ValueError: If an image cannot be decoded (and ``skip_errors``
+            is ``False``).
         """
-        return ImageEncodingMap(self, image_paths)
+        encodings = self._encode_paths(image_paths, skip_errors)
+        return ImageEncodingMap(encodings)
+
+    def _encode_paths(
+        self,
+        image_paths: Iterable[str],
+        skip_errors: bool,
+    ) -> dict[str, FloatNumpyArray]:
+        """
+        Encode every path, dropping duplicates and validating their type.
+
+        :param image_paths: Iterable of image file paths to encode.
+        :param skip_errors: If ``True``, unreadable images are skipped with a
+            warning instead of raising.
+        :return: A ``{image_path: encoding}`` dictionary in input order.
+        :raises TypeError: If any provided path is not a string.
+        """
+        encodings: dict[str, FloatNumpyArray] = {}
+        failures: list[str] = []
+        for path in image_paths:
+            if not isinstance(path, str):
+                raise TypeError(
+                    f"Image paths must be strings, got {type(path).__name__}."
+                )
+            if path in encodings:
+                continue
+            try:
+                encodings[path] = self._encode_path(path)
+            except (FileNotFoundError, ValueError, OSError):
+                if not skip_errors:
+                    raise
+                failures.append(path)
+
+        if failures:
+            warnings.warn(
+                f"Skipped {len(failures)} image(s) that could not be encoded.",
+                FutureWarning,
+                stacklevel=3,
+            )
+        return encodings
+
+    def _encode_path(self, path: str) -> FloatNumpyArray:
+        """
+        Open one image and return its flattened encoding.
+
+        :param path: Filesystem path of the image to encode.
+        :return: The flattened encoding vector for the image.
+        :raises FileNotFoundError: If the image file is missing.
+        :raises ValueError: If the image cannot be decoded.
+        """
+        try:
+            with Image.open(path) as image:
+                rgb_image = np.asarray(image.convert("RGB"))
+        except FileNotFoundError:
+            raise  # already clear and specific; let it propagate
+        except (UnidentifiedImageError, OSError) as exc:
+            raise ValueError(f"Could not read image {path!r}: {exc}") from exc
+        return self.encode(rgb_image).flatten()
 
     @property
     def similarity_func(self) -> SimilarityFunc:

--- a/pyvisim/image_store/image_store.py
+++ b/pyvisim/image_store/image_store.py
@@ -2,15 +2,13 @@ from __future__ import annotations
 
 import json
 import os
-import warnings
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Iterator, Mapping
 
 import numpy as np
-from PIL import Image, UnidentifiedImageError
 from safetensors import safe_open
 from safetensors.numpy import save_file
 
-from ..typing import Encoder, FloatNumpyArray
+from ..typing import FloatNumpyArray
 
 #: Name of the tensor holding the stacked encoding matrix on disk.
 _ENCODINGS_KEY = "encodings"
@@ -21,34 +19,22 @@ _FORMAT_VERSION = 1
 class ImageEncodingMap(Mapping[str, FloatNumpyArray]):
     """Map an image path to its encoding vector.
 
-    The full ``path -> encoding`` mapping can be written to and restored from
-    a safetensors file via :meth:`save_to_disk` and :meth:`load_from_disk`.
+    The full ``path -> encoding`` mapping can be written to and restored from a
+    safetensors file via :meth:`save_to_disk` and :meth:`load_from_disk`.
 
-    :param encoder: Encoder used to turn an image into a fixed-size vector. Any
-        object satisfying :class:`pyvisim.typing.Encoder` is accepted.
-    :param image_paths: Iterable of image file paths. Duplicates are dropped,
-        keeping the first occurrence. May be ``None`` to start empty.
-    :param skip_errors: If ``True``, images that cannot be read or encoded are
-        skipped with a warning instead of aborting construction.
-    :raises TypeError: If any provided path is not a string.
-    :raises FileNotFoundError: If an image file is missing (and
-        ``skip_errors`` is ``False``).
-    :raises ValueError: If an image cannot be decoded (and ``skip_errors`` is
-        ``False``).
+    :param encodings: Mapping of image path to its encoding
+        vector. May be ``None`` to start empty.
+    :raises TypeError: If any provided key is not a string.
     """
 
     def __init__(
         self,
-        encoder: Encoder,
-        image_paths: Iterable[str] | None = None,
-        *,
-        skip_errors: bool = False,
+        encodings: Mapping[str, FloatNumpyArray] | None = None,
     ) -> None:
-        self.encoder = encoder
         self._encodings: dict[str, FloatNumpyArray] = {}
 
-        if image_paths is not None:
-            self._encode_paths(image_paths, skip_errors)
+        if encodings is not None:
+            self._populate(encodings)
 
     def __len__(self) -> int:
         return len(self._encodings)
@@ -69,16 +55,13 @@ class ImageEncodingMap(Mapping[str, FloatNumpyArray]):
         return self._encodings[key]
 
     def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}(num_images={len(self)}, "
-            f"encoder={self.encoder.__class__.__name__})"
-        )
+        return f"{self.__class__.__name__}(num_images={len(self)})"
 
     def save_to_disk(self, file_path: str) -> None:
         """Persist the ``path -> encoding`` mapping to a safetensors file.
 
         The stacked encoding matrix is stored as a single tensor; the image
-        paths, encoder name and format version live in the file metadata.
+        paths and format version live in the file metadata.
 
         :param file_path: Destination ``.safetensors`` path. Overwritten if it
             exists.
@@ -101,17 +84,12 @@ class ImageEncodingMap(Mapping[str, FloatNumpyArray]):
         matrix = np.ascontiguousarray(np.stack(encodings))
         metadata = {
             "paths": json.dumps(saved_paths),
-            "encoder": self.encoder.__class__.__name__,
             "format_version": str(_FORMAT_VERSION),
         }
         save_file({_ENCODINGS_KEY: matrix}, file_path, metadata=metadata)
 
     @classmethod
-    def load_from_disk(
-        cls,
-        file_path: str,
-        encoder: Encoder,
-    ) -> ImageEncodingMap:
+    def load_from_disk(cls, file_path: str) -> ImageEncodingMap:
         """Rebuild an :class:`ImageEncodingMap` from a :meth:`save_to_disk` file.
 
         The encodings are restored directly from the file; no image is
@@ -119,8 +97,6 @@ class ImageEncodingMap(Mapping[str, FloatNumpyArray]):
 
         :param file_path: Path to a safetensors file produced by
             :meth:`save_to_disk`.
-        :param encoder: Encoder to attach. It should match the one used when
-            saving.
         :returns: A populated :class:`ImageEncodingMap`.
         :raises FileNotFoundError: If ``file_path`` does not exist.
         :raises ValueError: If the file is missing the required tensor or
@@ -143,59 +119,23 @@ class ImageEncodingMap(Mapping[str, FloatNumpyArray]):
                 )
             encodings = handle.get_tensor(_ENCODINGS_KEY)
             paths = json.loads(metadata["paths"])
-            stored_encoder = metadata.get("encoder")
 
-        if stored_encoder and stored_encoder != encoder.__class__.__name__:
-            warnings.warn(
-                f"Encoder mismatch: file saved with {stored_encoder!r}, "
-                f"loading with {encoder.__class__.__name__!r}.",
-                RuntimeWarning,
-                stacklevel=2,
-            )
+        return cls(
+            {
+                path: np.asarray(vector)
+                for path, vector in zip(paths, encodings, strict=True)
+            }
+        )
 
-        store = cls(encoder)
-        store._encodings = {
-            path: np.asarray(vector)
-            for path, vector in zip(paths, encodings, strict=True)
-        }
-        return store
+    def _populate(self, encodings: Mapping[str, FloatNumpyArray]) -> None:
+        """Store every ``path -> encoding`` pair, validating the path type.
 
-    def _encode_paths(self, image_paths: Iterable[str], skip_errors: bool) -> None:
-        """Encode every path, dropping duplicates and validating their type.
-
-        :param image_paths: Iterable of image file paths to encode.
-        :param skip_errors: If ``True``, unreadable images are skipped with a
-            warning instead of raising.
+        :param encodings: Mapping of image path to encoding vector.
+        :raises TypeError: If any key is not a string.
         """
-        failures: list[str] = []
-        for path in image_paths:
+        for path, vector in encodings.items():
             if not isinstance(path, str):
                 raise TypeError(
                     f"Image paths must be strings, got {type(path).__name__}."
                 )
-            if path in self._encodings:
-                continue
-            try:
-                self._encodings[path] = self._encode_path(path)
-            except (FileNotFoundError, ValueError, OSError):
-                if not skip_errors:
-                    raise
-                failures.append(path)
-
-        if failures:
-            warnings.warn(
-                f"Skipped {len(failures)} image(s) that could not be encoded.",
-                RuntimeWarning,
-                stacklevel=2,
-            )
-
-    def _encode_path(self, path: str) -> FloatNumpyArray:
-        """Open one image and return its flattened encoding."""
-        try:
-            with Image.open(path) as image:
-                rgb_image = np.asarray(image.convert("RGB"))
-        except FileNotFoundError:
-            raise  # already clear and specific; let it propagate
-        except (UnidentifiedImageError, OSError) as exc:
-            raise ValueError(f"Could not read image {path!r}: {exc}") from exc
-        return self.encoder.encode(rgb_image).flatten()
+            self._encodings[path] = np.asarray(vector)

--- a/pyvisim/retrieval/image_retriever.py
+++ b/pyvisim/retrieval/image_retriever.py
@@ -10,7 +10,7 @@ that ranks the gallery against one or more query images.
 from __future__ import annotations
 
 from ..functional import Candidate, retrieve_top_k_similar
-from ..typing import ImageInput
+from ..typing import Encoder, ImageInput
 from .index import ImageIndex
 
 
@@ -19,15 +19,23 @@ class ImageRetriever:
     Retrieve the most similar gallery images for a set of query images.
 
     :param index: The accelerated index to search against.
+    :param encoder: Encoder used to turn the query images into feature vectors.
+        It should match the one used to build the gallery encodings.
     """
 
-    def __init__(self, index: ImageIndex) -> None:
+    def __init__(self, index: ImageIndex, encoder: Encoder) -> None:
         self._index = index
+        self._encoder = encoder
 
     @property
     def index(self) -> ImageIndex:
         """The underlying :class:`~pyvisim.retrieval.ImageIndex`."""
         return self._index
+
+    @property
+    def encoder(self) -> Encoder:
+        """The encoder used to turn query images into feature vectors."""
+        return self._encoder
 
     def retrieve_top_k_similar(
         self,
@@ -38,7 +46,7 @@ class ImageRetriever:
         Return the top-k most similar gallery images for each query image.
 
         :param query_images: A single image or a batch/iterable of images to use
-            as queries. Anything accepted by the index's encoder is valid.
+            as queries. Anything accepted by the encoder is valid.
         :param k: Number of top similar gallery images to return per query.
         :return: One ranked list of :class:`~pyvisim.functional.Candidate`
             matches per query image, in the same order as ``query_images``.
@@ -46,7 +54,7 @@ class ImageRetriever:
         return retrieve_top_k_similar(
             query_images,
             self._index.encoding_map,
-            self._index.encoder,
+            self._encoder,
             k=k,
             index=self._index,
         )

--- a/pyvisim/retrieval/index/_base_index.py
+++ b/pyvisim/retrieval/index/_base_index.py
@@ -20,7 +20,7 @@ import faiss
 import numpy as np
 
 from ...image_store import ImageEncodingMap
-from ...typing import Encoder, Float32NumpyArray, FloatNumpyArray, IntNumpyArray
+from ...typing import Float32NumpyArray, FloatNumpyArray, IntNumpyArray
 
 #: Supported quantizer/metric choices, mapped to their FAISS metric constant.
 _METRICS: dict[str, int] = {
@@ -105,11 +105,6 @@ class ImageIndex(abc.ABC):
     def encoding_map(self) -> ImageEncodingMap:
         """The gallery :class:`~pyvisim.image_store.ImageEncodingMap`."""
         return self._encoding_map
-
-    @property
-    def encoder(self) -> Encoder:
-        """The encoder used to build the gallery encodings."""
-        return self._encoding_map.encoder
 
     @property
     def paths(self) -> list[str]:

--- a/tests/encoders/base/test_base_encoder.py
+++ b/tests/encoders/base/test_base_encoder.py
@@ -217,6 +217,70 @@ def test_generate_encoding_map_returns_image_encoding_map(
     assert len({vector.shape[0] for vector in vectors}) == 1
 
 
+def _write_rgb_image(array: np.ndarray, path: Path) -> str:
+    """Write a grayscale array out as an RGB PNG and return its path string.
+
+    :param array: source grayscale image array.
+    :param path: destination file path.
+    :returns: the saved file path as a string.
+    """
+    rgb = np.stack([array, array, array], axis=-1)
+    Image.fromarray(rgb).save(path)
+    return str(path)
+
+
+def test_generate_encoding_map_drops_duplicate_paths(
+    learned_vlad: VLADEncoder,
+    tmp_path: Path,
+    category_train_images_flat: list[np.ndarray],
+) -> None:
+    """Duplicate input paths collapse to a single registered entry."""
+    path = _write_rgb_image(category_train_images_flat[0], tmp_path / "img.png")
+    encoding_map = learned_vlad.generate_encoding_map([path, path])
+    assert list(encoding_map) == [path]
+
+
+def test_generate_encoding_map_non_string_path_raises(
+    learned_vlad: VLADEncoder,
+) -> None:
+    """A non-string path is rejected before any encoding happens."""
+    with pytest.raises(TypeError, match="Image paths must be strings"):
+        learned_vlad.generate_encoding_map([123])  # type: ignore[list-item]
+
+
+def test_generate_encoding_map_missing_file_raises(
+    learned_vlad: VLADEncoder, tmp_path: Path
+) -> None:
+    """A missing image file raises ``FileNotFoundError``."""
+    with pytest.raises(FileNotFoundError):
+        learned_vlad.generate_encoding_map([str(tmp_path / "gone.png")])
+
+
+def test_generate_encoding_map_unreadable_file_raises(
+    learned_vlad: VLADEncoder, tmp_path: Path
+) -> None:
+    """A file that is not a valid image raises ``ValueError``."""
+    bogus = tmp_path / "bogus.png"
+    bogus.write_text("this is not an image")
+    with pytest.raises(ValueError, match="Could not read image"):
+        learned_vlad.generate_encoding_map([str(bogus)])
+
+
+def test_generate_encoding_map_skip_errors_warns_and_keeps_good_images(
+    learned_vlad: VLADEncoder,
+    tmp_path: Path,
+    category_train_images_flat: list[np.ndarray],
+) -> None:
+    """``skip_errors`` warns about and omits images that fail to encode."""
+    good = _write_rgb_image(category_train_images_flat[0], tmp_path / "good.png")
+    missing = str(tmp_path / "missing.png")
+    with pytest.warns(FutureWarning, match="Skipped 1 image"):
+        encoding_map = learned_vlad.generate_encoding_map(
+            [good, missing], skip_errors=True
+        )
+    assert set(encoding_map) == {good}
+
+
 def test_repr_smoke(learned_vlad: VLADEncoder) -> None:
     """``repr`` names the encoder class and its RootSIFT feature extractor."""
     text = repr(learned_vlad)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -62,7 +62,13 @@ def gallery(
         arrays.append(array)
         paths.append(str(path))
     encoder = FlattenEncoder()
-    return arrays, paths, encoder, ImageEncodingMap(encoder, paths)
+    encoding_map = ImageEncodingMap(
+        {
+            path: encoder.encode(array)[0]
+            for path, array in zip(paths, arrays, strict=True)
+        }
+    )
+    return arrays, paths, encoder, encoding_map
 
 
 def test_returns_one_ranked_list_per_query_in_order(

--- a/tests/image_store/test_image_store.py
+++ b/tests/image_store/test_image_store.py
@@ -8,70 +8,54 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from PIL import Image
 from safetensors.numpy import save_file
 
-from pyvisim.encoders import FisherVectorEncoder, VLADEncoder
 from pyvisim.image_store import ImageEncodingMap
 
-#: Number of images materialized on disk for the test store.
+#: Number of encodings materialized for the test map.
 NUM_IMAGES = 4
-
-
-@pytest.fixture(scope="module")
-def encoder(category_train_images_flat: list[np.ndarray]) -> VLADEncoder:
-    """A small ``VLADEncoder`` learned once for this module.
-
-    :param category_train_images_flat: flattened training images to learn from.
-    :returns: a fitted ``VLADEncoder`` with ``n_clusters=4``.
-    """
-    enc = VLADEncoder(n_clusters=4, kmeans_params={"random_state": 0, "n_init": 3})
-    enc.learn(category_train_images_flat)
-    return enc
-
-
-@pytest.fixture(scope="module")
-def image_paths(
-    tmp_path_factory: pytest.TempPathFactory,
-    category_train_images_flat: list[np.ndarray],
-) -> list[str]:
-    """Write :data:`NUM_IMAGES` RGB PNGs to disk and return their paths.
-
-    :param tmp_path_factory: pytest's session-scoped temp directory factory.
-    :param category_train_images_flat: source grayscale training images.
-    :returns: a list of file-path strings, one per saved image.
-    """
-    directory = tmp_path_factory.mktemp("image_store_imgs")
-    paths: list[str] = []
-    for index in range(NUM_IMAGES):
-        gray = category_train_images_flat[index]
-        rgb = np.stack([gray, gray, gray], axis=-1)
-        path = directory / f"img_{index}.png"
-        Image.fromarray(rgb).save(path)
-        paths.append(str(path))
-    return paths
+#: Dimensionality of each test encoding vector.
+DIM = 6
 
 
 @pytest.fixture
-def image_map(encoder: VLADEncoder, image_paths: list[str]) -> ImageEncodingMap:
-    """An :class:`ImageEncodingMap` over the test images.
+def encodings() -> dict[str, np.ndarray]:
+    """A ``path -> vector`` mapping of precomputed encodings.
 
-    :param encoder: the learned encoder fixture.
-    :param image_paths: the on-disk image paths fixture.
-    :returns: an ``ImageEncodingMap`` whose encodings are computed up front.
+    :returns: an ordered dict of four equal-length random vectors.
     """
-    return ImageEncodingMap(encoder, image_paths)
+    rng = np.random.default_rng(0)
+    return {
+        f"img_{index}.png": rng.random(DIM).astype(np.float32)
+        for index in range(NUM_IMAGES)
+    }
 
 
-# encoding
+@pytest.fixture
+def image_map(encodings: dict[str, np.ndarray]) -> ImageEncodingMap:
+    """An :class:`ImageEncodingMap` over the precomputed encodings.
+
+    :param encodings: the ``path -> vector`` fixture.
+    :returns: an ``ImageEncodingMap`` wrapping ``encodings``.
+    """
+    return ImageEncodingMap(encodings)
 
 
-def test_access_returns_one_dimensional_vector(
-    image_map: ImageEncodingMap, image_paths: list[str]
+# Construction
+
+
+def test_access_returns_the_stored_vector(
+    image_map: ImageEncodingMap, encodings: dict[str, np.ndarray]
 ) -> None:
-    """Indexing a path returns its flattened, 1-D encoding vector."""
-    vector = image_map[image_paths[0]]
-    assert vector.ndim == 1
+    """Indexing a path returns the vector it was constructed with."""
+    path = next(iter(encodings))
+    assert np.allclose(image_map[path], encodings[path])
+
+
+def test_constructor_has_no_encoder_parameter() -> None:
+    """The map is decoupled from any encoder, so it takes no encoder."""
+    params = inspect.signature(ImageEncodingMap.__init__).parameters
+    assert "encoder" not in params
 
 
 def test_constructor_has_no_cache_size_parameter() -> None:
@@ -84,46 +68,43 @@ def test_constructor_has_no_cache_size_parameter() -> None:
 
 
 def test_iter_preserves_insertion_order(
-    image_map: ImageEncodingMap, image_paths: list[str]
+    image_map: ImageEncodingMap, encodings: dict[str, np.ndarray]
 ) -> None:
     """Iteration yields the registered paths in insertion order."""
-    assert list(image_map) == image_paths
+    assert list(image_map) == list(encodings)
 
 
 def test_dict_conversion_round_trips_keys(
-    image_map: ImageEncodingMap, image_paths: list[str]
+    image_map: ImageEncodingMap, encodings: dict[str, np.ndarray]
 ) -> None:
     """``dict(map)`` materializes every encoding keyed by its path."""
     as_dict = dict(image_map)
-    assert set(as_dict) == set(image_paths)
+    assert set(as_dict) == set(encodings)
     assert all(vector.ndim == 1 for vector in as_dict.values())
 
 
 def test_contains_reports_registered_paths(
-    image_map: ImageEncodingMap, image_paths: list[str]
+    image_map: ImageEncodingMap, encodings: dict[str, np.ndarray]
 ) -> None:
     """Membership tests report whether a path was registered."""
-    assert image_paths[0] in image_map
+    assert next(iter(encodings)) in image_map
     assert "not-a-registered-path" not in image_map
 
 
-# Path registration and key validation
+def test_empty_map_has_no_paths() -> None:
+    """An ``ImageEncodingMap`` may be created with no encodings at all."""
+    store = ImageEncodingMap()
+    assert len(store) == 0
+    assert list(store) == []
 
 
-def test_duplicate_paths_are_dropped(
-    encoder: VLADEncoder, image_paths: list[str]
-) -> None:
-    """Duplicate input paths collapse to a single registered entry."""
-    duplicated = image_paths + image_paths
-    store = ImageEncodingMap(encoder, duplicated)
-    assert len(store) == NUM_IMAGES
-    assert list(store) == image_paths
+# Key validation
 
 
-def test_non_string_path_raises_type_error(encoder: VLADEncoder) -> None:
-    """A non-string path is rejected at registration time."""
+def test_non_string_path_raises_type_error() -> None:
+    """A non-string path is rejected at construction time."""
     with pytest.raises(TypeError, match="Image paths must be strings"):
-        ImageEncodingMap(encoder, [123])  # type: ignore[list-item]
+        ImageEncodingMap({123: np.zeros(DIM)})  # type: ignore[dict-item]
 
 
 def test_unknown_path_raises_key_error(image_map: ImageEncodingMap) -> None:
@@ -138,68 +119,36 @@ def test_non_string_key_raises_key_error(image_map: ImageEncodingMap) -> None:
         image_map[42]  # type: ignore[index]
 
 
-def test_empty_map_has_no_paths(encoder: VLADEncoder) -> None:
-    """An ``ImageEncodingMap`` may be created with no paths at all."""
-    store = ImageEncodingMap(encoder)
-    assert len(store) == 0
-    assert list(store) == []
-
-
-# Encoding error propagation
-
-
-def test_missing_file_raises_file_not_found(
-    encoder: VLADEncoder, tmp_path: Path
-) -> None:
-    """A registered-but-missing file raises ``FileNotFoundError`` on construction."""
-    missing = str(tmp_path / "gone.png")
-    with pytest.raises(FileNotFoundError):
-        ImageEncodingMap(encoder, [missing])
-
-
-def test_unreadable_file_raises_value_error(
-    encoder: VLADEncoder, tmp_path: Path
-) -> None:
-    """A registered file that is not an image raises ``ValueError`` on construction."""
-    bogus = tmp_path / "bogus.png"
-    bogus.write_text("this is not an image")
-    with pytest.raises(ValueError, match="Could not read image"):
-        ImageEncodingMap(encoder, [str(bogus)])
-
-
-def test_skip_errors_warns_and_keeps_good_images(
-    encoder: VLADEncoder, image_paths: list[str], tmp_path: Path
-) -> None:
-    """``skip_errors`` warns about and omits images that fail to encode."""
-    missing = str(tmp_path / "missing.png")
-    with pytest.warns(RuntimeWarning, match="Skipped 1 image"):
-        store = ImageEncodingMap(encoder, [image_paths[0], missing], skip_errors=True)
-    assert set(store) == {image_paths[0]}
-
-
 # Persistence: save_to_disk / load_from_disk
 
 
 def test_save_and_load_round_trip(
-    image_map: ImageEncodingMap, encoder: VLADEncoder, tmp_path: Path
+    image_map: ImageEncodingMap,
+    encodings: dict[str, np.ndarray],
+    tmp_path: Path,
 ) -> None:
-    """A saved store reloads with identical encodings."""
-    expected = {path: image_map[path] for path in image_map}
+    """A saved map reloads with identical encodings."""
     target = str(tmp_path / "store.safetensors")
     image_map.save_to_disk(target)
 
-    loaded = ImageEncodingMap.load_from_disk(target, encoder)
-    assert set(loaded) == set(image_map)
-    assert len(loaded._encodings) == len(loaded)
-    for path, vector in expected.items():
+    loaded = ImageEncodingMap.load_from_disk(target)
+    assert list(loaded) == list(image_map)
+    for path, vector in encodings.items():
         assert np.allclose(loaded[path], vector)
 
 
-def test_save_empty_store_raises(encoder: VLADEncoder, tmp_path: Path) -> None:
-    """Saving a store with no images raises ``ValueError``."""
-    store = ImageEncodingMap(encoder)
+def test_save_empty_store_raises(tmp_path: Path) -> None:
+    """Saving a map with no encodings raises ``ValueError``."""
+    store = ImageEncodingMap()
     with pytest.raises(ValueError, match="empty ImageStore"):
         store.save_to_disk(str(tmp_path / "empty.safetensors"))
+
+
+def test_save_inconsistent_lengths_raises(tmp_path: Path) -> None:
+    """Saving encodings of differing lengths raises ``ValueError``."""
+    store = ImageEncodingMap({"a.png": np.zeros(3), "b.png": np.zeros(4)})
+    with pytest.raises(ValueError, match="same length"):
+        store.save_to_disk(str(tmp_path / "ragged.safetensors"))
 
 
 def test_save_to_missing_directory_raises(image_map: ImageEncodingMap) -> None:
@@ -208,13 +157,13 @@ def test_save_to_missing_directory_raises(image_map: ImageEncodingMap) -> None:
         image_map.save_to_disk("/no/such/directory/store.safetensors")
 
 
-def test_load_missing_file_raises(encoder: VLADEncoder, tmp_path: Path) -> None:
+def test_load_missing_file_raises(tmp_path: Path) -> None:
     """Loading a path that does not exist raises ``FileNotFoundError``."""
     with pytest.raises(FileNotFoundError, match="No such safetensors file"):
-        ImageEncodingMap.load_from_disk(str(tmp_path / "absent.safetensors"), encoder)
+        ImageEncodingMap.load_from_disk(str(tmp_path / "absent.safetensors"))
 
 
-def test_load_file_missing_tensor_raises(encoder: VLADEncoder, tmp_path: Path) -> None:
+def test_load_file_missing_tensor_raises(tmp_path: Path) -> None:
     """Loading a safetensors file without the encodings tensor raises ``ValueError``."""
     target = tmp_path / "wrong.safetensors"
     save_file(
@@ -223,30 +172,12 @@ def test_load_file_missing_tensor_raises(encoder: VLADEncoder, tmp_path: Path) -
         metadata={"paths": json.dumps([])},
     )
     with pytest.raises(ValueError, match="missing the 'encodings' tensor"):
-        ImageEncodingMap.load_from_disk(str(target), encoder)
+        ImageEncodingMap.load_from_disk(str(target))
 
 
-def test_load_file_missing_paths_metadata_raises(
-    encoder: VLADEncoder, tmp_path: Path
-) -> None:
+def test_load_file_missing_paths_metadata_raises(tmp_path: Path) -> None:
     """Loading a safetensors file without the paths metadata raises ``ValueError``."""
     target = tmp_path / "no_paths.safetensors"
     save_file({"encodings": np.zeros((1, 3), dtype=np.float32)}, str(target))
     with pytest.raises(ValueError, match="missing the 'paths' metadata"):
-        ImageEncodingMap.load_from_disk(str(target), encoder)
-
-
-def test_load_with_mismatched_encoder_warns(
-    image_map: ImageEncodingMap,
-    encoder: VLADEncoder,
-    category_train_images_flat: list[np.ndarray],
-    tmp_path: Path,
-) -> None:
-    """Loading with a different encoder class warns about the mismatch."""
-    target = str(tmp_path / "store.safetensors")
-    image_map.save_to_disk(target)
-
-    other = FisherVectorEncoder(n_components=4, gmm_params={"random_state": 0})
-    other.learn(category_train_images_flat)
-    with pytest.warns(RuntimeWarning, match="Encoder mismatch"):
-        ImageEncodingMap.load_from_disk(target, other)
+        ImageEncodingMap.load_from_disk(str(target))

--- a/tests/retrieval/test_image_index.py
+++ b/tests/retrieval/test_image_index.py
@@ -11,21 +11,6 @@ from pyvisim.retrieval.index import (
     ImageIndexIVFFlat,
     ImageIndexIVFPQ,
 )
-from pyvisim.typing import FloatNumpyArray, ImageInput
-
-
-class _StubEncoder:
-    """Minimal encoder; the index reads ``.encoder`` but never calls it."""
-
-    def encode(
-        self,
-        images: ImageInput,
-        *,
-        dims: str = "HWC",
-        value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> FloatNumpyArray:
-        """Return a throw-away vector (unused by the indexes)."""
-        return np.zeros((1, 1), dtype=np.float32)
 
 
 def _random_map(num: int, dim: int, seed: int = 0) -> ImageEncodingMap:
@@ -37,11 +22,9 @@ def _random_map(num: int, dim: int, seed: int = 0) -> ImageEncodingMap:
     :returns: A populated ``ImageEncodingMap`` not backed by any image files.
     """
     rng = np.random.default_rng(seed)
-    store = ImageEncodingMap(_StubEncoder())
-    store._encodings = {
-        f"img_{i}.png": rng.random(dim).astype(np.float32) for i in range(num)
-    }
-    return store
+    return ImageEncodingMap(
+        {f"img_{i}.png": rng.random(dim).astype(np.float32) for i in range(num)}
+    )
 
 
 # Construction and exposed state
@@ -62,12 +45,11 @@ def test_len_dim_and_paths_match_insertion_order() -> None:
     assert index.paths == list(store.keys())
 
 
-def test_encoder_and_encoding_map_are_exposed() -> None:
-    """The source encoding map and its encoder are reachable from the index."""
+def test_encoding_map_is_exposed() -> None:
+    """The source encoding map is reachable from the index."""
     store = _random_map(num=20, dim=8)
     index = ImageIndexIVFFlat(store, nlist=2)
     assert index.encoding_map is store
-    assert index.encoder is store.encoder
 
 
 # Search
@@ -159,7 +141,7 @@ def test_unknown_quantizer_raises() -> None:
 def test_empty_encoding_map_raises() -> None:
     """An empty gallery cannot be indexed."""
     with pytest.raises(ValueError, match="empty ImageEncodingMap"):
-        ImageIndexIVFFlat(ImageEncodingMap(_StubEncoder()), nlist=1)
+        ImageIndexIVFFlat(ImageEncodingMap(), nlist=1)
 
 
 def test_nlist_larger_than_gallery_raises() -> None:

--- a/tests/retrieval/test_image_retriever.py
+++ b/tests/retrieval/test_image_retriever.py
@@ -57,11 +57,16 @@ def retriever(
         arrays.append(array)
         paths.append(str(path))
     encoder = FlattenEncoder()
-    encoding_map = ImageEncodingMap(encoder, paths)
+    encoding_map = ImageEncodingMap(
+        {
+            path: encoder.encode(array)[0]
+            for path, array in zip(paths, arrays, strict=True)
+        }
+    )
     index = ImageIndexIVFFlat(
         encoding_map, quantizer="inner_product", nlist=2, nprobe=2
     )
-    return arrays, paths, ImageRetriever(index)
+    return arrays, paths, ImageRetriever(index, encoder)
 
 
 def test_index_property_returns_the_index(


### PR DESCRIPTION
### Related Issues

- fixes #issue-number <!-- replace with the decoupling issue number -->

### Proposed Changes:

This decouples the encoder from the encoding map. Until now `ImageEncodingMap` held a reference to an encoder and read/encoded images itself, so the map's job (storing image encodings) was tangled up with the encoder's job (producing them). The index then reached back through the map to grab the encoder for query-time search. That coupling made the map awkward to build from precomputed vectors and meant the map couldn't really exist on its own.

After this PR the map is just a `path -> vector` store. Three things changed:

- **`ImageEncodingMap` is now a plain mapping.** Its constructor takes a precomputed `{path: vector}` mapping (or nothing, to start empty) and never touches an encoder or the filesystem. The image-reading/encoding logic (`_encode_paths`/`_encode_path`) moved onto the encoder, where it belongs. `save_to_disk`/`load_from_disk` dropped the encoder metadata and the encoder argument, so a saved map is fully self-contained.
- **Encoding happens before the map is built.** `ImageEncoderBase.generate_encoding_map` (and `Pipeline.generate_encoding_map`) now encode the images up front and wrap the result in the map. Both also gained a `skip_errors` flag, which previously only lived on the map constructor and wasn't reachable through `generate_encoding_map`.
- **`ImageRetriever` takes the encoder directly.** The index no longer exposes an `encoder` property (it used to read it off the map). The retriever is now constructed as `ImageRetriever(index, encoder)` and uses that encoder to encode queries.

The inner-product normalization rule (`faiss.normalize_L2` before vectors hit the store) was already handled in `ImageIndex.__init__` for `quantizer="inner_product"`, so no change was needed there.

I also added `Pillow` to the dependencies — the image reading needs it and it had been coming in transitively.

> [!WARNING]
> **Breaking changes:**
> - `ImageEncodingMap(encoder, image_paths)` → `ImageEncodingMap(encodings_mapping)`. Use `encoder.generate_encoding_map(paths)` to build one from images.
> - `ImageEncodingMap.load_from_disk(path, encoder)` → `ImageEncodingMap.load_from_disk(path)`.
> - `ImageIndex.encoder` removed.
> - `ImageRetriever(index)` → `ImageRetriever(index, encoder)`.

### How did you test it?

- Updated the unit suite to the new API and added coverage for the relocated behaviour: `generate_encoding_map` now owns the duplicate-dropping, missing-file (`FileNotFoundError`), unreadable-file (`ValueError`) and `skip_errors` (warns + keeps good images) tests. The map's own tests build it from a dict and exercise the mapping protocol + save/load round trip.
- `make test-unit` — 150 passed.
- `make test-types` — clean on all changed files.
- `make fmt` / pre-commit (ruff check + format) — clean.

### Notes for the reviewer

- The `skip_errors` warning is emitted as `FutureWarning` to follow the repo's "use FutureWarning for warning cases" convention; the old code raised it as `RuntimeWarning`, and the test was updated to match. Shout if you'd rather keep `RuntimeWarning` for this non-deprecation case.
- `_encode_paths`/`_encode_path` are duplicated between `ImageEncoderBase` and `Pipeline` (per the request to keep this logic as a method on the encoder rather than a shared util). `Pipeline` isn't an `ImageEncoderBase` subclass, so it carries its own copy — consistent with the existing duplication of `encode`/`generate_encoding_map` between the two.
- Heads up, unrelated to this PR: there's a stale, untracked `pyvisim/retrieval/image_index.py` (a leftover near-duplicate of the tracked `pyvisim/retrieval/index/image_index.py` from the earlier move). Its imports are broken for its location and it's imported nowhere, but it trips up `mypy`. Recommend deleting it.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] When applicable: I have reviewed the AI-generated code sections, according to [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#using-ai-to-contribute).
- [x] I have run [pre-commit hooks](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#set-up-developer-environment) and fixed any issue.
