### PR TITLE
refactor: remove pca and clustering_model public setters

### DIFF
--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -235,9 +235,9 @@ class ImageEncoderBase(SimilarityMetric):
             self._load_pretrained_weights(weights)  # TODO: removed with version 1.0.0
         else:
             if pca is not None:
-                self.pca = pca
+                self._set_pca(pca)
             if clustering_model is not None:
-                self.clustering_model = clustering_model
+                self._set_clustering_model(clustering_model)
 
     # TODO: removed with version 1.0.0
     def _load_pretrained_weights(self, weights: KMeansWeights | GMMWeights) -> None:
@@ -260,10 +260,10 @@ class ImageEncoderBase(SimilarityMetric):
         )
         if "PCA" in weights.name:
             pca_state = load_encoder_state(_CLUSTERING_TO_PCA_MAPPING[weights].path)
-            self.pca = PCA.from_dict(pca_state["pca"])
+            self._set_pca(PCA.from_dict(pca_state["pca"]))
         clustering_state = load_encoder_state(weights.path)
-        self.clustering_model = self._clustering_model_cls.from_dict(
-            clustering_state["clustering_model"]
+        self._set_clustering_model(
+            self._clustering_model_cls.from_dict(clustering_state["clustering_model"])
         )
 
     @property
@@ -310,10 +310,6 @@ class ImageEncoderBase(SimilarityMetric):
     def clustering_model(self) -> ClusteringModelBase | None:
         return self._clustering_model
 
-    @clustering_model.setter
-    def clustering_model(self, clustering_model: ClusteringModelBase) -> None:
-        self._set_clustering_model(clustering_model)
-
     def _set_clustering_model(self, clustering_model: ClusteringModelBase) -> None:
         """
         Validates the given clustering model against the current PCA or
@@ -358,8 +354,14 @@ class ImageEncoderBase(SimilarityMetric):
     def pca(self) -> PCA | None:
         return self._pca
 
-    @pca.setter
-    def pca(self, pca: PCA) -> None:
+    def _set_pca(self, pca: PCA) -> None:
+        """
+        Validates and stores the given PCA model.
+
+        :param pca: PCA model to validate and store.
+        :raises ValueError: If ``pca`` is not a :class:`~pyvisim.clustering.PCA` instance
+            or its dimensions are incompatible with the feature extractor or clustering model.
+        """
         if not isinstance(pca, PCA):
             raise ValueError(
                 f"The PCA model must be an instance of pyvisim.clustering.PCA, not {type(pca)}"
@@ -535,9 +537,9 @@ class ImageEncoderBase(SimilarityMetric):
             ],
         )
         if state["pca"] is not None:
-            encoder.pca = PCA.from_dict(state["pca"])
-        encoder.clustering_model = cls._clustering_model_cls.from_dict(
-            state["clustering_model"]
+            encoder._set_pca(PCA.from_dict(state["pca"]))
+        encoder._set_clustering_model(
+            cls._clustering_model_cls.from_dict(state["clustering_model"])
         )
         return encoder
 

--- a/pyvisim/encoders/fisher_vector.py
+++ b/pyvisim/encoders/fisher_vector.py
@@ -130,13 +130,12 @@ class FisherVectorEncoder(ImageEncoderBase):
     def clustering_model(self) -> GaussianMixtureModel:
         return cast(GaussianMixtureModel, self._clustering_model)
 
-    @clustering_model.setter
-    def clustering_model(self, model: ClusteringModelBase) -> None:
-        if not isinstance(model, GaussianMixtureModel):
+    def _set_clustering_model(self, clustering_model: ClusteringModelBase) -> None:
+        if not isinstance(clustering_model, GaussianMixtureModel):
             raise ValueError(
-                f"The clustering model must be an instance of pyvisim.clustering.GaussianMixtureModel, not {type(model)}"
+                f"The clustering model must be an instance of pyvisim.clustering.GaussianMixtureModel, not {type(clustering_model)}"
             )
-        self._set_clustering_model(model)
+        super()._set_clustering_model(clustering_model)
 
     def encode(
         self,

--- a/pyvisim/encoders/vlad.py
+++ b/pyvisim/encoders/vlad.py
@@ -130,13 +130,12 @@ class VLADEncoder(ImageEncoderBase):
     def clustering_model(self) -> KMeans:
         return cast(KMeans, self._clustering_model)
 
-    @clustering_model.setter
-    def clustering_model(self, model: ClusteringModelBase) -> None:
-        if not isinstance(model, KMeans):
+    def _set_clustering_model(self, clustering_model: ClusteringModelBase) -> None:
+        if not isinstance(clustering_model, KMeans):
             raise ValueError(
-                f"The clustering model must be an instance of pyvisim.clustering.KMeans, not {type(model)}"
+                f"The clustering model must be an instance of pyvisim.clustering.KMeans, not {type(clustering_model)}"
             )
-        self._set_clustering_model(model)
+        super()._set_clustering_model(clustering_model)
 
     def encode(
         self,

--- a/tests/encoders/base/test_base_encoder.py
+++ b/tests/encoders/base/test_base_encoder.py
@@ -85,12 +85,10 @@ def test_feature_extractor_setter_type_check() -> None:
         encoder.feature_extractor = "x"  # type: ignore[assignment]
 
 
-def test_pca_setter_type_check() -> None:
-    """Assigning a non-PCA object to ``pca`` raises ``ValueError``."""
+def test_pca_is_read_only() -> None:
+    """``pca`` is a read-only property; direct assignment raises ``AttributeError``."""
     encoder = VLADEncoder(n_clusters=8)
-    with pytest.raises(
-        ValueError, match="must be an instance of pyvisim.clustering.PCA"
-    ):
+    with pytest.raises(AttributeError):
         encoder.pca = object()  # type: ignore[assignment]
 
 

--- a/tests/encoders/fisher/test_fisher.py
+++ b/tests/encoders/fisher/test_fisher.py
@@ -67,11 +67,11 @@ def test_wrong_weights_class_raises() -> None:
         FisherVectorEncoder(weights=KMeansWeights.OXFORD102_K256_SIFT)
 
 
-def test_clustering_setter_rejects_non_gmm() -> None:
-    """Assigning a non-GMM clustering model raises ``ValueError``."""
+def test_clustering_model_is_read_only() -> None:
+    """``clustering_model`` is a read-only property; direct assignment raises ``AttributeError``."""
     encoder = FisherVectorEncoder(n_components=8)
-    with pytest.raises(ValueError, match="GaussianMixtureModel"):
-        encoder.clustering_model = KMeans(8)
+    with pytest.raises(AttributeError):
+        encoder.clustering_model = KMeans(8)  # type: ignore[assignment]
 
 
 def test_encode_shape_no_pca(

--- a/tests/encoders/vlad/test_vlad.py
+++ b/tests/encoders/vlad/test_vlad.py
@@ -66,13 +66,11 @@ def test_wrong_weights_class_raises() -> None:
         VLADEncoder(weights=GMMWeights.OXFORD102_K256_SIFT)
 
 
-def test_clustering_setter_rejects_non_kmeans() -> None:
-    """Assigning a non-KMeans clustering model raises ``ValueError``."""
+def test_clustering_model_is_read_only() -> None:
+    """``clustering_model`` is a read-only property; direct assignment raises ``AttributeError``."""
     encoder = VLADEncoder(n_clusters=8)
-    with pytest.raises(
-        ValueError, match="must be an instance of pyvisim.clustering.KMeans"
-    ):
-        encoder.clustering_model = GaussianMixtureModel(8)
+    with pytest.raises(AttributeError):
+        encoder.clustering_model = GaussianMixtureModel(8)  # type: ignore[assignment]
 
 
 def test_encode_shape_no_pca(


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

The `pca` and `clustering_model` attributes on `ImageEncoderBase` (and its subclasses) were writable properties, which meant a caller could swap out a trained clustering model or PCA after the encoder was already fitted. That's a bad idea — the encoder's output shape and internal state all depend on those models, so silently replacing them mid-life invites hard-to-debug inconsistencies.

This PR makes both attributes read-only by removing their public setters. The validation logic that lived in those setters isn't gone — it moved to private methods (`_set_pca`, `_set_clustering_model`) that are still called internally during construction and deserialization. The public-facing `pca` and `clustering_model` properties now only expose a getter.

A small structural improvement fell out of this naturally: `VLADEncoder` and `FisherVectorEncoder` previously overrode the `clustering_model` setter to enforce their type constraints (KMeans vs. GaussianMixtureModel). Since there's no setter to override any more, they instead override `_set_clustering_model`, add the isinstance check, then delegate to `super()`. That's a cleaner hook point anyway.

> [!WARNING]
> **Breaking change:**
> - `encoder.pca = ...` and `encoder.clustering_model = ...` now raise `AttributeError`. Use the constructor parameters (`pca_params`, `n_clusters` / `n_components`) and `learn()` to build a fitted encoder, or `load_from_disk()` / `from_pretrained()` to restore one.

### How did you test it?

- Updated the three setter-validation tests (`test_pca_setter_type_check`, `test_clustering_setter_rejects_non_kmeans`, `test_clustering_setter_rejects_non_gmm`) to assert that direct assignment raises `AttributeError` instead.
- `make test-unit` — 257 passed, 0 failures.
- `make test-types` — clean on all 36 source files. Also deleted the stale untracked `pyvisim/retrieval/image_index.py` leftover that was already blocking mypy (flagged in the previous PR's reviewer notes).
- Pre-commit hooks (ruff check + format) — clean on all changed files.

### Notes for the reviewer

- The internal `_set_pca` / `_set_clustering_model` methods are still called in `__init__`, `_load_pretrained_weights`, and `load_from_disk`, so serialization round-trips and the deprecated `weights=` constructor path still work correctly.
- `convert_pkl_to_encoder.py` (the one-off migration script, untracked) was also updated to use the private methods.
- `feature_extractor` still has a public setter — that attribute is less tightly coupled to the trained state (you can legitimately want to swap out the extractor) so it's left as-is and out of scope here.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] When applicable: I have reviewed the AI-generated code sections, according to [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#using-ai-to-contribute).
- [x] I have run [pre-commit hooks](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#set-up-developer-environment) and fixed any issue.
