### PR TITLE
bugfix: use 'backbone' instead of 'model' in DeepConvFeature._from_config

### DIFF
--- a/pyvisim/features/_features.py
+++ b/pyvisim/features/_features.py
@@ -485,7 +485,7 @@ class DeepConvFeature(FeatureExtractorBase):
         if not default_model:
             model.load_state_dict(_decode_state_dict(config["state_dict"]))
         return cls(
-            model=model,
+            backbone=model,
             target_submodule=config.get("target_submodule"),
             layer_index=config["layer_index"],
             spatial_encoding=config["spatial_encoding"],


### PR DESCRIPTION
When reconstructing the deep feat encoder from pretrained, the deprecated param "model" was used instead of "backbone", so this PR only changed this single line.