### PR TITLE
Feat: refractor image encoder base

### DIFF
--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -33,6 +33,7 @@ _CLUSERING_ENCODER_FILE_FORMAT_VERSION_COMPATIBILITY: dict[tuple[int, int], bool
     #
     # However, (2, 1) might not be True!!
 }
+_EncoderT = TypeVar("_EncoderT", bound="ImageEncoderBase")
 _ClusteringEncoderT = TypeVar("_ClusteringEncoderT", bound="ClusteringBasedEncoder")
 
 
@@ -168,6 +169,32 @@ class ImageEncoderBase(SimilarityMetric):
         return self._similarity_func_name
 
     @abc.abstractmethod
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialises this encoder into a JSON-safe state dictionary.
+
+        Every concrete encoder must define how it serialises itself. The
+        returned mapping has to contain at least the keys listed in
+        :attr:`_STATE_KEYS` (notably ``"encoder_class"``) so that
+        :meth:`load_from_disk` can validate the file and dispatch it to the
+        right class. Arrays may be embedded as ``__ndarray__`` nodes; the
+        serialization layer stores them as binary tensors.
+
+        :return: A JSON-safe encoder description suitable for :meth:`from_dict`.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    @abc.abstractmethod
+    def from_dict(cls: type[_EncoderT], state: dict[str, Any]) -> _EncoderT:
+        """
+        Rebuilds an encoder from a dictionary produced by :meth:`to_dict`.
+
+        :param state: A JSON-safe encoder description from :meth:`to_dict`.
+        :return: A ready-to-use encoder instance.
+        """
+        raise NotImplementedError
+
     @abc.abstractmethod
     def encode(
         self,

--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -33,22 +33,6 @@ _CLUSERING_ENCODER_FILE_FORMAT_VERSION_COMPATIBILITY: dict[tuple[int, int], bool
     #
     # However, (2, 1) might not be True!!
 }
-_ENCODER_STATE_KEYS = frozenset(
-    {
-        "encoder_class",
-        "clustering_model",
-        "pca",
-        "power_norm_weight",
-        "norm_order",
-        "epsilon",
-        "flatten",
-        "raise_error_when_pca_incompatible",
-        "similarity_func",
-        "feature_extractor",
-    }
-)
-
-
 _ClusteringEncoderT = TypeVar("_ClusteringEncoderT", bound="ClusteringBasedEncoder")
 
 
@@ -183,6 +167,7 @@ class ImageEncoderBase(SimilarityMetric):
         """The name of the configured similarity metric (e.g. ``"cosine"``)."""
         return self._similarity_func_name
 
+    @abc.abstractmethod
     @abc.abstractmethod
     def encode(
         self,
@@ -328,6 +313,22 @@ class ClusteringBasedEncoder(FeatureBasedEncoder):
                                         than the PCA model's output size, an Error will be raised"""
 
     _clustering_model_cls: ClassVar[type[ClusteringModelBase]]
+
+    #: Keys that a serialised state must contain to be a valid encoder file.
+    _STATE_KEYS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "encoder_class",
+            "clustering_model",
+            "pca",
+            "power_norm_weight",
+            "norm_order",
+            "epsilon",
+            "flatten",
+            "raise_error_when_pca_incompatible",
+            "similarity_func",
+            "feature_extractor",
+        }
+    )
 
     def __init__(
         self,
@@ -683,7 +684,7 @@ class ClusteringBasedEncoder(FeatureBasedEncoder):
             was saved by a different encoder class.
         """
         state = load_encoder_state(pathlib.Path(path))
-        if not _ENCODER_STATE_KEYS.issubset(state):
+        if not cls._STATE_KEYS.issubset(state):
             raise ValueError(f"File {path} is not a valid .encoder file.")
         # TODO: in the future, verify format version by checking
         # compatibility via _CLUSERING_ENCODER_FILE_FORMAT_VERSION_COMPATIBILITY

--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -49,7 +49,7 @@ _ENCODER_STATE_KEYS = frozenset(
 )
 
 
-_EncoderT = TypeVar("_EncoderT", bound="ImageEncoderBase")
+_ClusteringEncoderT = TypeVar("_ClusteringEncoderT", bound="ClusteringBasedEncoder")
 
 
 class _PretrainedModels(Enum):
@@ -148,8 +148,159 @@ class _PretrainedEncoder(Enum):
 
 class ImageEncoderBase(SimilarityMetric):
     """
-    Base class for image encoders. An image encoder is a class that
-    generates a vector representation of an image. Subclasses use a combination of:
+    Base class for all image encoders. An image encoder generates a vector
+    representation of an image which can be used for indexing, retrieval,
+    clustering or classification tasks.
+
+    This base only knows how to encode images into vectors (:meth:`encode`) and
+    how to compare those vectors with a similarity function. Subclasses add the
+    machinery they need on top of that, e.g. a feature extractor
+    (:class:`FeatureBasedEncoder`) or a clustering model
+    (:class:`ClusteringBasedEncoder`).
+
+    :param similarity_func: Name of the built-in similarity metric to use. One of
+        ``"cosine"`` (default), ``"euclidean"``, ``"l1"`` or ``"manhattan"``.
+    """
+
+    def __init__(self, similarity_func: str = "cosine"):
+        # Set important attributes via setters to trigger error handling
+        self._similarity_func: SimilarityFunc
+        self._similarity_func_name: str
+        self.similarity_func = similarity_func
+
+    @property
+    def similarity_func(self) -> SimilarityFunc:
+        """The resolved similarity function callable."""
+        return self._similarity_func
+
+    @similarity_func.setter
+    def similarity_func(self, name: str) -> None:
+        self._similarity_func = get_similarity_func(name)
+        self._similarity_func_name = name
+
+    @property
+    def similarity_func_name(self) -> str:
+        """The name of the configured similarity metric (e.g. ``"cosine"``)."""
+        return self._similarity_func_name
+
+    @abc.abstractmethod
+    def encode(
+        self,
+        images: ImageInput,
+        *,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
+    ) -> FloatNumpyArray:
+        """
+        Encodes one or more images into a batch of vector representations.
+
+        Each image is normalized to a canonical ``uint8`` ``(H, W, C)`` array
+        before feature extraction, so NumPy arrays, torch tensors and other
+        array-like inputs are all accepted. When a batch axis is present (via
+        ``dims``), every image in the batch is encoded.
+
+        :param images: A single ``MatLike`` image, a batched array, or an
+            iterable of images. Consider using an iterator for large datasets.
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
+            (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
+            width × channels (NumPy/OpenCV single-image layout, **default**);
+            ``"CHW"`` is channels × height × width (PyTorch single-image layout);
+            ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
+            See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in;
+            converted into the canonical ``[0, 255]`` range.
+        :return: vector representations of the given images
+        """
+        raise NotImplementedError
+
+    def similarity_score(
+        self,
+        images1: ImageInput,
+        images2: ImageInput,
+        *,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
+    ) -> Float32NumpyArray:
+        """
+        Computes vector encodings for two images and calculates the similarity score between them.
+
+        :param images1: First (batch of) image(s) as ``MatLike``.
+        :param images2: Second (batch of) image(s) as ``MatLike``.
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
+            (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
+            width × channels (NumPy/OpenCV single-image layout, **default**);
+            ``"CHW"`` is channels × height × width (PyTorch single-image layout);
+            ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
+            See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in;
+            converted into the canonical ``[0, 255]`` range.
+        :return: Similarity matrix between the two image batches.
+        """
+        vector1 = self.encode(images1, dims=dims, value_range=value_range)
+        vector2 = self.encode(images2, dims=dims, value_range=value_range)
+        result = self.similarity_func(vector1, vector2)
+        return np.asarray(result, dtype=np.float32)
+
+    def __repr__(self) -> str:
+        return (
+            self.__class__.__name__ + f"(similarity_func={self.similarity_func_name})"
+        )
+
+
+class FeatureBasedEncoder(ImageEncoderBase):
+    """
+    Base class for encoders that derive their vector representation from local
+    features extracted by a :class:`~pyvisim.features.FeatureExtractorBase`
+    (e.g. SIFT, SURF or deep features).
+
+    :param feature_extractor: Feature extractor instance (should implement
+        ``__call__``). Defaults to :class:`~pyvisim.features.RootSIFT`.
+    :param similarity_func: Name of the built-in similarity metric to use. One of
+        ``"cosine"`` (default), ``"euclidean"``, ``"l1"`` or ``"manhattan"``.
+    """
+
+    def __init__(
+        self,
+        feature_extractor: FeatureExtractorBase | None = None,
+        similarity_func: str = "cosine",
+    ):
+        self._feature_extractor: FeatureExtractorBase
+        super().__init__(similarity_func=similarity_func)
+        self.feature_extractor = (
+            feature_extractor if feature_extractor is not None else RootSIFT()
+        )
+
+    @property
+    def feature_extractor(self) -> FeatureExtractorBase:
+        return self._feature_extractor
+
+    @feature_extractor.setter
+    def feature_extractor(self, feature_extractor: FeatureExtractorBase) -> None:
+        self._validate_feature_extractor(feature_extractor)
+        self._feature_extractor = feature_extractor
+
+    def _validate_feature_extractor(
+        self, feature_extractor: FeatureExtractorBase
+    ) -> None:
+        """
+        Validates a candidate feature extractor before it is stored.
+
+        :param feature_extractor: Feature extractor to validate.
+        :raises TypeError: If ``feature_extractor`` is not a
+            :class:`~pyvisim.features.FeatureExtractorBase` instance.
+        """
+        if not isinstance(feature_extractor, FeatureExtractorBase):
+            raise TypeError(
+                f"feature_extractor must be an instance of FeatureExtractorBase, not {type(feature_extractor)}"
+            )
+
+
+class ClusteringBasedEncoder(FeatureBasedEncoder):
+    """
+    Base class for image encoders that aggregate local features with a
+    clustering model. Subclasses (VLAD and Fisher Vector) use a combination of:
 
     - A feature extractor: Extract local features from an image (e.g. SIFT, SURF, or Deep Features).
     - A clustering model (K-Means for VLAD or GMM for Fisher Vector): aggregates local features to their
@@ -194,11 +345,8 @@ class ImageEncoderBase(SimilarityMetric):
         raise_error_when_pca_incompatible: bool = True,
     ):
         # Set important attributes via setters to trigger error handling
-        self._feature_extractor: FeatureExtractorBase
         self._clustering_model: ClusteringModelBase | None = None
         self._pca: PCA | None = None
-        self._similarity_func: SimilarityFunc
-        self._similarity_func_name: str
 
         self.power_norm_weight = power_norm_weight
         self.norm_order = norm_order
@@ -206,9 +354,10 @@ class ImageEncoderBase(SimilarityMetric):
         self.flatten = flatten
         self.raise_error_when_pca_incompatible = raise_error_when_pca_incompatible
 
-        self.similarity_func = similarity_func
-        self.feature_extractor = (
-            feature_extractor if feature_extractor is not None else RootSIFT()
+        # The feature extractor setter validates against the (currently unset)
+        # PCA / clustering model, so both must already exist as ``None`` above.
+        super().__init__(
+            feature_extractor=feature_extractor, similarity_func=similarity_func
         )
 
         if weights is not None:
@@ -246,16 +395,24 @@ class ImageEncoderBase(SimilarityMetric):
             self._clustering_model_cls.from_dict(clustering_state["clustering_model"])
         )
 
-    @property
-    def feature_extractor(self) -> FeatureExtractorBase:
-        return self._feature_extractor
+    def _validate_feature_extractor(
+        self, feature_extractor: FeatureExtractorBase
+    ) -> None:
+        """
+        Validates a candidate feature extractor against the configured PCA or
+        clustering model before it is stored.
 
-    @feature_extractor.setter
-    def feature_extractor(self, feature_extractor: FeatureExtractorBase) -> None:
-        if not isinstance(feature_extractor, FeatureExtractorBase):
-            raise TypeError(
-                f"feature_extractor must be an instance of FeatureExtractorBase, not {type(feature_extractor)}"
-            )
+        In addition to the type check performed by the base class, the feature
+        extractor output size must match the input size of the fitted PCA (if
+        any) or otherwise the fitted clustering model.
+
+        :param feature_extractor: Feature extractor to validate.
+        :raises TypeError: If ``feature_extractor`` is not a
+            :class:`~pyvisim.features.FeatureExtractorBase` instance.
+        :raises RuntimeError: If its output size is incompatible with the
+            fitted PCA or clustering model.
+        """
+        super()._validate_feature_extractor(feature_extractor)
         if self._pca is not None and self._pca.is_fitted:
             if feature_extractor.output_dim != self._pca.n_features_in:
                 raise RuntimeError(
@@ -269,22 +426,6 @@ class ImageEncoderBase(SimilarityMetric):
                         f"Feature Extractor outputs shape {feature_extractor.output_dim}, "
                         f"But clustering model accepts input dim {self._clustering_model.n_features_in}"
                     )
-        self._feature_extractor = feature_extractor
-
-    @property
-    def similarity_func(self) -> SimilarityFunc:
-        """The resolved similarity function callable."""
-        return self._similarity_func
-
-    @similarity_func.setter
-    def similarity_func(self, name: str) -> None:
-        self._similarity_func = get_similarity_func(name)
-        self._similarity_func_name = name
-
-    @property
-    def similarity_func_name(self) -> str:
-        """The name of the configured similarity metric (e.g. ``"cosine"``)."""
-        return self._similarity_func_name
 
     @property
     def clustering_model(self) -> ClusteringModelBase | None:
@@ -434,8 +575,8 @@ class ImageEncoderBase(SimilarityMetric):
 
     @classmethod
     def from_pretrained(
-        cls: type[_EncoderT], pretrained: _PretrainedEncoder
-    ) -> _EncoderT:
+        cls: type[_ClusteringEncoderT], pretrained: _PretrainedEncoder
+    ) -> _ClusteringEncoderT:
         """
         Loads a bundled pretrained encoder.
 
@@ -483,7 +624,9 @@ class ImageEncoderBase(SimilarityMetric):
         }
 
     @classmethod
-    def from_dict(cls: type[_EncoderT], state: dict[str, Any]) -> _EncoderT:
+    def from_dict(
+        cls: type[_ClusteringEncoderT], state: dict[str, Any]
+    ) -> _ClusteringEncoderT:
         """
         Rebuilds an encoder from a dictionary produced by :meth:`to_dict`.
 
@@ -528,9 +671,9 @@ class ImageEncoderBase(SimilarityMetric):
 
     @classmethod
     def load_from_disk(
-        cls: type[_EncoderT],
+        cls: type[_ClusteringEncoderT],
         path: str | pathlib.Path,
-    ) -> _EncoderT:
+    ) -> _ClusteringEncoderT:
         """
         Loads an encoder previously saved with :meth:`save_to_disk`.
 
@@ -550,66 +693,6 @@ class ImageEncoderBase(SimilarityMetric):
                 f"Load it with {state['encoder_class']}.load_from_disk instead."
             )
         return cls.from_dict(state)
-
-    @abc.abstractmethod
-    def encode(
-        self,
-        images: ImageInput,
-        *,
-        dims: str = "HWC",
-        value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> FloatNumpyArray:
-        """
-        Encodes one or more images into a batch of vector representations.
-
-        Each image is normalized to a canonical ``uint8`` ``(H, W, C)`` array
-        before feature extraction, so NumPy arrays, torch tensors and other
-        array-like inputs are all accepted. When a batch axis is present (via
-        ``dims``), every image in the batch is encoded.
-
-        :param images: A single ``MatLike`` image, a batched array, or an
-            iterable of images. Consider using an iterator for large datasets.
-        :param dims: Axis-label string, one character per array axis in order:
-            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
-            (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
-            width × channels (NumPy/OpenCV single-image layout, **default**);
-            ``"CHW"`` is channels × height × width (PyTorch single-image layout);
-            ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
-            See :mod:`pyvisim.typing`.
-        :param value_range: The ``(low, high)`` range the input values live in;
-            converted into the canonical ``[0, 255]`` range.
-        :return: vector representations of the given images
-        """
-        raise NotImplementedError
-
-    def similarity_score(
-        self,
-        images1: ImageInput,
-        images2: ImageInput,
-        *,
-        dims: str = "HWC",
-        value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> Float32NumpyArray:
-        """
-        Computes vector encodings for two images and calculates the similarity score between them.
-
-        :param images1: First (batch of) image(s) as ``MatLike``.
-        :param images2: Second (batch of) image(s) as ``MatLike``.
-        :param dims: Axis-label string, one character per array axis in order:
-            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
-            (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
-            width × channels (NumPy/OpenCV single-image layout, **default**);
-            ``"CHW"`` is channels × height × width (PyTorch single-image layout);
-            ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
-            See :mod:`pyvisim.typing`.
-        :param value_range: The ``(low, high)`` range the input values live in;
-            converted into the canonical ``[0, 255]`` range.
-        :return: Similarity matrix between the two image batches.
-        """
-        vector1 = self.encode(images1, dims=dims, value_range=value_range)
-        vector2 = self.encode(images2, dims=dims, value_range=value_range)
-        result = self.similarity_func(vector1, vector2)
-        return np.asarray(result, dtype=np.float32)
 
     def __repr__(self) -> str:
         n_clusters = (

--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -147,6 +147,12 @@ class ImageEncoderBase(SimilarityMetric):
         ``"cosine"`` (default), ``"euclidean"``, ``"l1"`` or ``"manhattan"``.
     """
 
+    #: Keys a serialised state must contain to be a valid encoder file.
+    #: Subclasses extend this with their own required keys.
+    _STATE_KEYS: ClassVar[frozenset[str]] = frozenset(
+        {"encoder_class", "similarity_func"}
+    )
+
     def __init__(self, similarity_func: str = "cosine"):
         # Set important attributes via setters to trigger error handling
         self._similarity_func: SimilarityFunc
@@ -254,6 +260,46 @@ class ImageEncoderBase(SimilarityMetric):
         vector2 = self.encode(images2, dims=dims, value_range=value_range)
         result = self.similarity_func(vector1, vector2)
         return np.asarray(result, dtype=np.float32)
+
+    def save_to_disk(self, path: str | pathlib.Path) -> pathlib.Path:
+        """
+        Saves the serialised state of this encoder to a ``.encoder`` file.
+
+        :param path: Target file path. The ``.encoder`` suffix is appended if missing.
+        :return: The path of the written file.
+        :raises NotFittedError: If the encoder is not ready to be serialised
+            (see :meth:`to_dict`).
+        """
+        path = pathlib.Path(path)
+        if path.suffix != _ENCODER_FILE_SUFFIX:
+            path = path.with_name(path.name + _ENCODER_FILE_SUFFIX)
+        save_encoder_state(self.to_dict(), path)
+        return path
+
+    @classmethod
+    def load_from_disk(
+        cls: type[_EncoderT],
+        path: str | pathlib.Path,
+    ) -> _EncoderT:
+        """
+        Loads an encoder previously saved with :meth:`save_to_disk`.
+
+        :param path: Path to the ``.encoder`` file.
+        :return: A ready-to-use encoder instance.
+        :raises ValueError: If the file is not a valid ``.encoder`` file or
+            was saved by a different encoder class.
+        """
+        state = load_encoder_state(pathlib.Path(path))
+        if not cls._STATE_KEYS.issubset(state):
+            raise ValueError(f"File {path} is not a valid .encoder file.")
+        # TODO: in the future, verify the file's format version against the
+        # class-specific compatibility table before reconstructing.
+        if state["encoder_class"] != cls.__name__:
+            raise ValueError(
+                f"File {path} was saved by {state['encoder_class']}. "
+                f"Load it with {state['encoder_class']}.load_from_disk instead."
+            )
+        return cls.from_dict(state)
 
     def __repr__(self) -> str:
         return (
@@ -681,46 +727,6 @@ class ClusteringBasedEncoder(FeatureBasedEncoder):
             cls._clustering_model_cls.from_dict(state["clustering_model"])
         )
         return encoder
-
-    def save_to_disk(self, path: str | pathlib.Path) -> pathlib.Path:
-        """
-        Saves the learned state of this encoder to a ``.encoder`` file.
-
-
-        :param path: Target file path. The ``.encoder`` suffix is appended if missing.
-        :return: The path of the written file.
-        :raises NotFittedError: If the clustering model is missing or not fitted.
-        """
-        path = pathlib.Path(path)
-        if path.suffix != _ENCODER_FILE_SUFFIX:
-            path = path.with_name(path.name + _ENCODER_FILE_SUFFIX)
-        save_encoder_state(self.to_dict(), path)
-        return path
-
-    @classmethod
-    def load_from_disk(
-        cls: type[_ClusteringEncoderT],
-        path: str | pathlib.Path,
-    ) -> _ClusteringEncoderT:
-        """
-        Loads an encoder previously saved with :meth:`save_to_disk`.
-
-        :param path: Path to the ``.encoder`` file.
-        :return: A ready-to-use encoder instance.
-        :raises ValueError: If the file is not a valid ``.encoder`` file or
-            was saved by a different encoder class.
-        """
-        state = load_encoder_state(pathlib.Path(path))
-        if not cls._STATE_KEYS.issubset(state):
-            raise ValueError(f"File {path} is not a valid .encoder file.")
-        # TODO: in the future, verify format version by checking
-        # compatibility via _CLUSERING_ENCODER_FILE_FORMAT_VERSION_COMPATIBILITY
-        if state["encoder_class"] != cls.__name__:
-            raise ValueError(
-                f"File {path} was saved by {state['encoder_class']}. "
-                f"Load it with {state['encoder_class']}.load_from_disk instead."
-            )
-        return cls.from_dict(state)
 
     def __repr__(self) -> str:
         n_clusters = (

--- a/pyvisim/encoders/_base_encoder.py
+++ b/pyvisim/encoders/_base_encoder.py
@@ -25,9 +25,9 @@ from .utils import iter_images
 setup_logging()
 
 _ENCODER_FILE_SUFFIX = ".encoder"
-_ENCODER_FILE_FORMAT_VERSION = 1
-_ENCODER_FILE_FORMAT_VERSION_COMPATIBILITY: dict[tuple[int, int], bool] = {
-    # TODO: when the next _ENCODER_FILE_FORMAT_VERSION comes, check if
+_CLUSERING_ENCODER_FILE_FORMAT_VERSION = 1
+_CLUSERING_ENCODER_FILE_FORMAT_VERSION_COMPATIBILITY: dict[tuple[int, int], bool] = {
+    # TODO: when the next _CLUSERING_ENCODER_FILE_FORMAT_VERSION comes, check if
     # it's forward / backward compatible, then add entries like:
     # (1, 2): True,  # version 1 can read files from version 2
     #
@@ -610,7 +610,7 @@ class ClusteringBasedEncoder(FeatureBasedEncoder):
                 "fitted. Call 'learn' first."
             )
         return {
-            "format_version": _ENCODER_FILE_FORMAT_VERSION,
+            "format_version": _CLUSERING_ENCODER_FILE_FORMAT_VERSION,
             "encoder_class": type(self).__name__,
             "clustering_model": self._clustering_model.to_dict(),
             "pca": self._pca.to_dict() if self._pca is not None else None,
@@ -686,7 +686,7 @@ class ClusteringBasedEncoder(FeatureBasedEncoder):
         if not _ENCODER_STATE_KEYS.issubset(state):
             raise ValueError(f"File {path} is not a valid .encoder file.")
         # TODO: in the future, verify format version by checking
-        # compatibility via _ENCODER_FILE_FORMAT_VERSION_COMPATIBILITY
+        # compatibility via _CLUSERING_ENCODER_FILE_FORMAT_VERSION_COMPATIBILITY
         if state["encoder_class"] != cls.__name__:
             raise ValueError(
                 f"File {path} was saved by {state['encoder_class']}. "

--- a/pyvisim/encoders/fisher_vector.py
+++ b/pyvisim/encoders/fisher_vector.py
@@ -6,8 +6,8 @@ from .._base_classes import FeatureExtractorBase
 from .._config import MODEL_FILES_PATH
 from ..clustering import PCA, ClusteringModelBase, GaussianMixtureModel
 from ..encoders._base_encoder import (
+    ClusteringBasedEncoder,
     GMMWeights,
-    ImageEncoderBase,
     _PretrainedEncoder,
 )
 from ..typing import (
@@ -44,7 +44,7 @@ class PretrainedFisher(_PretrainedEncoder):
     )
 
 
-class FisherVectorEncoder(ImageEncoderBase):
+class FisherVectorEncoder(ClusteringBasedEncoder):
     """
     This class serves as an encoder that transforms input images into Fisher Vector descriptors.
 

--- a/pyvisim/encoders/pipeline.py
+++ b/pyvisim/encoders/pipeline.py
@@ -3,13 +3,9 @@ from typing import Any, cast
 
 import numpy as np
 
-from .._base_classes import SimilarityMetric
-from .._utils import get_similarity_func
 from ..typing import (
-    Float32NumpyArray,
     FloatNumpyArray,
     ImageInput,
-    SimilarityFunc,
 )
 from ._base_encoder import ImageEncoderBase
 from .utils import iter_images
@@ -18,10 +14,10 @@ from .utils import iter_images
 _PIPELINE_FORMAT_VERSION = 1
 
 
-class Pipeline(SimilarityMetric):
+class Pipeline(ImageEncoderBase):
     """
     A pipeline for computing feature vectors using a set of
-    descriptor-based encoders (e.g., VLAD, Fisher, etc.).
+    encoders.
 
     Currently, all vectors computed using the Encoders listed
     will always be flattened, because different Encoders also
@@ -41,7 +37,7 @@ class Pipeline(SimilarityMetric):
     ):
         self._check_valid_encoders(encoders)
         self.encoders = encoders
-        self.similarity_func = similarity_func
+        super().__init__(similarity_func=similarity_func)
 
     def _check_valid_encoders(self, encoders: list[ImageEncoderBase]) -> None:
         """
@@ -120,58 +116,20 @@ class Pipeline(SimilarityMetric):
         image_list = list(iter_images(images, dims=dims, value_range=value_range))
         all_encodings = []
         for metric in self.encoders:
-            a = metric.flatten  # each encoder has to be flattened to be usable here. Saving the original state temporarily
-            metric.flatten = True
+            # Each encoder has to be flattened to be usable here. Encoders that
+            # do not expose a ``flatten`` flag are assumed to already emit flat
+            # ``(num_imgs, feature_dim)`` encodings.
+            has_flatten = hasattr(metric, "flatten")
+            if has_flatten:
+                original_flatten = metric.flatten  # type: ignore[attr-defined]
+                metric.flatten = True  # type: ignore[attr-defined]
             encodings = metric.encode(
                 image_list
             )  # Each of size (num_imgs, feature_dim)
             all_encodings.append(encodings)
-            metric.flatten = a
+            if has_flatten:
+                metric.flatten = original_flatten  # type: ignore[attr-defined]
         return np.hstack(all_encodings)
-
-    @property
-    def similarity_func(self) -> SimilarityFunc:
-        """The resolved similarity function callable."""
-        return self._similarity_func
-
-    @similarity_func.setter
-    def similarity_func(self, name: str) -> None:
-        self._similarity_func = get_similarity_func(name)
-        self._similarity_func_name = name
-
-    @property
-    def similarity_func_name(self) -> str:
-        """The name of the configured similarity metric (e.g. ``"cosine"``)."""
-        return self._similarity_func_name
-
-    def similarity_score(
-        self,
-        images1: ImageInput,
-        images2: ImageInput,
-        *,
-        dims: str = "HWC",
-        value_range: tuple[float, float] = (0.0, 255.0),
-    ) -> Float32NumpyArray:
-        """
-        Computes vector encodings for two images and calculates the similarity score between them.
-
-        :param images1: First (batch of) image(s) as ``MatLike``.
-        :param images2: Second (batch of) image(s) as ``MatLike``.
-        :param dims: Axis-label string, one character per array axis in order:
-            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
-            (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
-            width × channels (NumPy/OpenCV single-image layout, **default**);
-            ``"CHW"`` is channels × height × width (PyTorch single-image layout);
-            ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
-            See :mod:`pyvisim.typing`.
-        :param value_range: The ``(low, high)`` range the input values live in;
-            converted into the canonical ``[0, 255]`` range.
-        :return: Similarity matrix between the two image batches.
-        """
-        vector1 = self.encode(images1, dims=dims, value_range=value_range)
-        vector2 = self.encode(images2, dims=dims, value_range=value_range)
-        result = self.similarity_func(vector1, vector2)
-        return np.asarray(result, dtype=np.float32)
 
     # def fit(self, images: Iterable[np.ndarray], reduce_dimension: bool = False, reduce_factor: int=2) -> None:
     #     """

--- a/pyvisim/encoders/pipeline.py
+++ b/pyvisim/encoders/pipeline.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 import numpy as np
 
@@ -29,6 +29,11 @@ class Pipeline(ImageEncoderBase):
     """
 
     _logger = logging.getLogger("Pipeline")
+
+    #: Keys a serialised state must contain to be a valid pipeline file.
+    _STATE_KEYS: ClassVar[frozenset[str]] = frozenset(
+        {"encoder_class", "encoders", "similarity_func"}
+    )
 
     def __init__(
         self,

--- a/pyvisim/encoders/vlad.py
+++ b/pyvisim/encoders/vlad.py
@@ -6,7 +6,7 @@ from .._base_classes import FeatureExtractorBase
 from .._config import MODEL_FILES_PATH
 from ..clustering import PCA, ClusteringModelBase, KMeans
 from ..encoders._base_encoder import (
-    ImageEncoderBase,
+    ClusteringBasedEncoder,
     KMeansWeights,
     _PretrainedEncoder,
 )
@@ -39,7 +39,7 @@ class PretrainedVLAD(_PretrainedEncoder):
     )
 
 
-class VLADEncoder(ImageEncoderBase):
+class VLADEncoder(ClusteringBasedEncoder):
     """
     This class encodes images into VLAD descriptor vectors
     using a chosen feature extractor and a K-Means clustering model,

--- a/tests/encoders/base/test_base_encoder.py
+++ b/tests/encoders/base/test_base_encoder.py
@@ -12,7 +12,7 @@ from sklearn.exceptions import NotFittedError
 
 from pyvisim.clustering import PCA
 from pyvisim.encoders import FisherVectorEncoder, VLADEncoder
-from pyvisim.encoders._base_encoder import ImageEncoderBase
+from pyvisim.encoders._base_encoder import ClusteringBasedEncoder
 from pyvisim.features import Lambda, RootSIFT
 
 if TYPE_CHECKING:
@@ -51,7 +51,7 @@ def test_similarity_func_rejects_unknown_name() -> None:
 # §3.2 ImageEncoderBase shared behaviour (exercised via VLADEncoder)
 
 
-class _NoModelEncoder(ImageEncoderBase):
+class _NoModelEncoder(ClusteringBasedEncoder):
     """Minimal concrete encoder used to test the "no clustering model" path."""
 
     def encode(self, images: Iterable[np.ndarray], flatten: bool = True) -> np.ndarray:


### PR DESCRIPTION
### Related Issues

- None

### Proposed Changes:

The old `ImageEncoderBase` was doing too much — it bundled the feature extractor, the clustering model, the similarity function, and the persistence logic all in one flat class. That made it awkward to add encoders that use features but no clustering (or no features at all), and it forced `Pipeline` to re-implement `similarity_func`, `similarity_score`, and related boilerplate from scratch.

This PR splits `ImageEncoderBase` into a proper three-level hierarchy:

- **`ImageEncoderBase`** — thin base that only knows how to `encode` images and compute `similarity_score`. No feature extractor, no clustering.
- **`FeatureBasedEncoder(ImageEncoderBase)`** — adds a `feature_extractor` attribute and the validation logic around it.
- **`ClusteringBasedEncoder(FeatureBasedEncoder)`** — the former `ImageEncoderBase`; adds the clustering model, PCA, power norm, save/load machinery, etc. `VLADEncoder` and `FisherVectorEncoder` now inherit from this.

`Pipeline` is updated to inherit from `ImageEncoderBase` instead of `SimilarityMetric`, which lets it drop its duplicate `similarity_func` property, `similarity_func_name`, and the full `similarity_score` implementation — all inherited for free now.

Two smaller clean-ups landed alongside:

- `_ENCODER_FILE_FORMAT_VERSION` → `_CLUSERING_ENCODER_FILE_FORMAT_VERSION` (and the compatibility dict) to make clear these version constants belong to `ClusteringBasedEncoder`, not the whole encoder family.
- `Pipeline.encode` now uses `hasattr(metric, "flatten")` before touching that attribute, so non-clustering encoders can be mixed into a pipeline without crashing.

### How did you test it?

- Existing unit tests in `tests/encoders/base/test_base_encoder.py` were updated to import `ClusteringBasedEncoder` and still pass.
- The `_NoModelEncoder` fixture was rebased onto `ClusteringBasedEncoder`; all downstream test behaviour is unchanged.
- Manual smoke check: instantiate `VLADEncoder`, `FisherVectorEncoder`, and `Pipeline` with a mixed encoder list; `encode` and `similarity_score` produce the same outputs as before the refactor.

### Notes for the reviewer

The most interesting part is the `_validate_feature_extractor` override in `ClusteringBasedEncoder` — it calls `super()._validate_feature_extractor` first (type check) and then adds the PCA/clustering size checks on top. Worth confirming that the call order is correct and that the `None` guards for `_pca` and `_clustering_model` are still tight.

The `# type: ignore[attr-defined]` comments in `Pipeline.encode` are intentional: mypy can't see `flatten` through the `ImageEncoderBase` type, but we guard with `hasattr` at runtime.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] When applicable: I have reviewed the AI-generated code sections, according to [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#using-ai-to-contribute).
- [x] I have run [pre-commit hooks](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#set-up-developer-environment) and fixed any issue.
