### PR TITLE
Feat/clip encoder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Install dependencies
-        run: uv sync --group test
+        run: uv sync --group test --extra nn
 
       - name: Run pytest with coverage
         run: uv run --group test pytest -m "not slow"
@@ -115,7 +115,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Install dependencies
-        run: uv sync --group test
+        run: uv sync --group test --extra nn
 
       - name: Run slow tests
         run: uv run --group test pytest -m "slow"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- `CLIPEncoder` (in `pyvisim.encoders`): a pretrained-CLIP image encoder built on
+  open_clip. It maps an image straight to a CLIP embedding, so there's no feature
+  extractor, clustering model, or `learn` step. Embeddings are L2-normalized by default,
+  and it plugs into the usual `similarity_score` / `save_to_disk` / `load_from_disk`
+  machinery.
+
+  ```python
+  from pyvisim.encoders import CLIPEncoder
+
+  clip = CLIPEncoder(model_name="ViT-B-32", pretrained="laion2b_s34b_b79k")
+  embeddings = clip.encode(images)
+  ```
+
+  Saving stores only the model identifiers (`model_name`, `pretrained` tag, etc.), not
+  the weights, so `.encoder` files stay tiny and open_clip re-fetches the weights on load.
+- `nn` optional extra (`pip install "pyvisim[nn]"`) that pulls in `open_clip_torch` for
+  the neural-network encoders. open_clip is imported lazily, so importing `pyvisim` never
+  requires it; you only hit the error (with an install hint) when you build a
+  `CLIPEncoder` without it installed.
+
 ## [0.6.0] - 2026-06-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ have any suggestions or questions!
 2. **Deep Learning Embeddings**  
    - Generate VLAD or Fisher vectors from neural network embeddings, e.g., VGG16 or other models.
    - Enhance your deep learning pipeline by leveraging traditional encoding methods on top of CNN features.
+   - Or skip the aggregation entirely and use `CLIPEncoder` for ready-made CLIP embeddings (`pip install "pyvisim[nn]"`).
 
 3. **Image Clustering**  
    - Cluster images based on their similarities to group them by category or content. An example and benchmarking
@@ -129,6 +130,13 @@ To use the library, you can simply install it via pip:
 ```bash
 pip install pyvisim
 ```
+
+If you want to use the `CLIPEncoder`, you need to install the `nn` extra:
+
+```bash
+pip install "pyvisim[nn]"
+```
+
 or clone the repository and install it locally:
 
 ```bash

--- a/docs/encoders/README.md
+++ b/docs/encoders/README.md
@@ -1,22 +1,28 @@
 # Encoders
 
-An encoder turns an image into a single fixed-size vector by extracting local
-descriptors and aggregating them against a learned visual vocabulary. The resulting
-vectors are used for retrieval, clustering, and classification.
+An encoder turns an image into a single fixed-size vector you can use for
+retrieval, clustering, and classification. Two families live here: the
+clustering-based encoders (VLAD, Fisher Vector) that extract local descriptors and
+aggregate them against a learned visual vocabulary, and `CLIPEncoder`, which runs
+the image through a pretrained CLIP network end to end.
 
 | Object | File | Aggregation model | Output size |
 |--------|------|-------------------|-------------|
 | [`VLADEncoder`](vlad.md) | [`vlad.py`](../../pyvisim/encoders/vlad.py) | KMeans | `K * D` |
 | [`FisherVectorEncoder`](fisher_vector.md) | [`fisher_vector.py`](../../pyvisim/encoders/fisher_vector.py) | Gaussian Mixture Model | `2 * K * D + K` |
+| [`CLIPEncoder`](clip.md) | [`clip.py`](../../pyvisim/encoders/clip.py) | n/a (pretrained CLIP) | model-defined (512 for `ViT-B-32`) |
 | [`Pipeline`](pipeline.md) | [`pipeline.py`](../../pyvisim/encoders/pipeline.py) | n/a (composes encoders) | sum of members |
 
 where `K` is the number of clusters and `D` is the local descriptor dimension.
 
-Shared machinery lives in [`ImageEncoderBase`](base_encoder.md). Each encoder builds its
-aggregation model from the [`pyvisim.clustering`](../clustering/README.md) package using
-the parameters you pass at construction, then fits it in `learn`. Trained encoders are
-saved and restored with `save_to_disk` / `load_from_disk`; the older pretrained-weight
-enums in [weights.md](weights.md) still work but are deprecated.
+Shared machinery lives in [`ImageEncoderBase`](base_encoder.md). The clustering
+encoders build their aggregation model from the
+[`pyvisim.clustering`](../clustering/README.md) package using the parameters you
+pass at construction, then fit it in `learn`. Trained encoders are saved and
+restored with `save_to_disk` / `load_from_disk`; the older pretrained-weight enums
+in [weights.md](weights.md) still work but are deprecated. `CLIPEncoder` skips the
+`learn` step entirely (its weights are already pretrained) and needs the `nn`
+extra: `pip install "pyvisim[nn]"`.
 
 ## VLAD vs Fisher Vector
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,13 @@ dependencies = [
 #   uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
 # Replace cu124 with the CUDA version matching your system (e.g. cu121, cu118).
 
+# Optional extras. Install with e.g. 'pip install "pyvisim[nn]"'.
+[project.optional-dependencies]
+# Neural-network encoders (e.g. CLIPEncoder) built on top of open_clip.
+nn = [
+    "open_clip_torch",
+]
+
 [project.urls]
 Homepage = "https://github.com/MechaCritter/Python-Visual-Similarity"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ plugins = ["numpy.typing.mypy_plugin"]
 [[tool.mypy.overrides]]
 module = [
   "faiss.*",
+  "open_clip.*",
   "scipy.*",
   "sklearn.*",
   "torchvision.*",

--- a/pyvisim/encoders/README.md
+++ b/pyvisim/encoders/README.md
@@ -2,12 +2,14 @@
 
 ## Overview
 The "encoders" module is responsible for computing image similarities, or more precisely the vector representations of visual content in
-images which can be used for tasks such as indexing, retrieval, clustering, and classification of images. The encoders in this module utilize
+images which can be used for tasks such as indexing, retrieval, clustering, and classification of images. Most encoders in this module utilize
 a combination of feature extraction techniques, clustering models, and a certain similarity function to generate these vector representations,
-depending on the specific implementation of the encoder.
-This module currently contains three core components:
+depending on the specific implementation of the encoder. The CLIP encoder is the exception: it is a pretrained neural network that maps an
+image directly to an embedding.
+This module currently contains these core components:
 - VLAD (Vector of Locally Aggregated Descriptors) Encoder
 - Fisher Vector Encoder
+- CLIP Encoder
 - Similarity Metric Pipeline
 
 ALl the feature extraction classes/methods are implemented in the `features` module.
@@ -64,6 +66,27 @@ why `load_from_disk` only needs the path.
 pyvisim also ships pretrained encoders. Load one with `VLADEncoder.from_pretrained(PretrainedVLAD.X)` or
 `FisherVectorEncoder.from_pretrained(PretrainedFisher.X)`. The older `weights=KMeansWeights.X` / `weights=GMMWeights.X`
 constructor argument is deprecated and will be removed in `1.0.0`.
+
+## CLIP Encoder
+The `CLIPEncoder` wraps a pretrained [open_clip](https://github.com/mlfoundations/open_clip) model and maps each image
+straight to a CLIP embedding, so there is no feature extractor, clustering model, or `learn` step. `open_clip` is a
+heavyweight dependency, so it ships as the optional `nn` extra and is imported lazily: importing `pyvisim` never requires
+it, and the error (with an install hint) only shows up if you actually build a `CLIPEncoder` without it installed.
+
+```bash
+pip install "pyvisim[nn]"
+```
+
+```python
+from pyvisim.encoders import CLIPEncoder
+
+clip = CLIPEncoder(model_name="ViT-B-32", pretrained="laion2b_s34b_b79k")
+embeddings = clip.encode(images)  # (num_images, D); L2-normalized by default
+```
+
+The weights download on first use and are cached by open_clip. Saving stores only the model identifiers (not the
+weights), so `.encoder` files stay tiny and `load_from_disk` re-fetches the weights to reproduce the original encodings.
+See [the CLIP docs](../../docs/encoders/clip.md) for the full rundown.
 
 ## Similarity Metric Pipeline
 The _Pipeline_ class is designed to handle multiple encoders simultaneously to compute feature vectors. It takes

--- a/pyvisim/encoders/__init__.py
+++ b/pyvisim/encoders/__init__.py
@@ -1,4 +1,5 @@
 from ._base_encoder import GMMWeights, KMeansWeights
+from .clip import CLIPEncoder
 from .fisher_vector import FisherVectorEncoder, PretrainedFisher
 from .pipeline import Pipeline
 from .vlad import PretrainedVLAD, VLADEncoder
@@ -6,6 +7,7 @@ from .vlad import PretrainedVLAD, VLADEncoder
 __all__ = [
     "VLADEncoder",
     "FisherVectorEncoder",
+    "CLIPEncoder",
     "Pipeline",
     "KMeansWeights",
     "GMMWeights",

--- a/pyvisim/encoders/clip.py
+++ b/pyvisim/encoders/clip.py
@@ -1,0 +1,236 @@
+"""CLIP image encoder built on top of the `open_clip <https://github.com/mlfoundations/open_clip>`_ library.
+
+:mod:`open_clip` is an optional dependency installed by the ``nn`` extra
+(``pip install "pyvisim[nn]"``). It is imported lazily through
+:class:`~pyvisim.lazy_import.OptionalImport`, so importing :mod:`pyvisim` never
+requires it: the actionable :class:`ImportError` is raised only when a
+:class:`CLIPEncoder` is constructed without the dependency installed.
+"""
+
+from typing import Any
+
+import numpy as np
+import torch
+from PIL import Image
+
+from .._config import setup_logging
+from ..lazy_import import OptionalImport
+from ..typing import Float32NumpyArray, ImageInput, UInt8NumpyArray
+from ._base_encoder import ImageEncoderBase
+from .utils import iter_images
+
+with OptionalImport(package="open_clip_torch", extra="nn") as _open_clip_import:
+    import open_clip
+
+setup_logging()
+
+#: Bumped whenever the serialised :class:`CLIPEncoder` state layout changes.
+_CLIP_ENCODER_FILE_FORMAT_VERSION = 1
+
+
+def _resolve_device(device: str | None) -> str:
+    """
+    Resolve a requested device, falling back to CPU when CUDA is unavailable.
+
+    :param device: ``"cuda"``, ``"cpu"`` or ``None`` to auto-select.
+    :return: ``"cuda"`` if requested/available, otherwise ``"cpu"``.
+    """
+    if device is None:
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cuda" and not torch.cuda.is_available():
+        return "cpu"
+    return device
+
+
+class CLIPEncoder(ImageEncoderBase):
+    """
+    Encodes images into CLIP embeddings using a pretrained `open_clip` model.
+
+    The model and its matching preprocessing transform are loaded from
+    `open_clip` at construction time. :meth:`encode` runs each image through the
+    image tower of the model and returns its embedding; embeddings are
+    L2-normalized by default so they can be compared directly with a dot product
+    or the cosine similarity metric.
+
+    Because the weights are pretrained and downloaded by `open_clip`,
+    serialization stores only the identifiers needed to rebuild the encoder
+    (``model_name`` and ``pretrained`` tag) rather than the weights themselves.
+
+    :param model_name: `open_clip` architecture name, e.g. ``"ViT-B-32"``. See
+        https://pypi.org/project/open-clip-torch/ for all available models.
+    :param pretrained: `open_clip` pretrained weight tag, e.g.
+        ``"laion2b_s34b_b79k"``. Run ``open_clip.list_pretrained()`` to see the
+        available tags. ``None`` builds the architecture with randomly
+        initialized weights (no download).
+    :param device: Device to run the model on (``"cpu"`` or ``"cuda"``).
+        Defaults to ``"cuda"`` when a CUDA device is available, else ``"cpu"``.
+    :param normalize: Whether to L2-normalize the returned embeddings
+        (default ``True``).
+    :param similarity_func: Name of the built-in similarity metric to use. One of
+        ``"cosine"`` (default), ``"euclidean"``, ``"l1"`` or ``"manhattan"``.
+    :raises ImportError: If the optional ``open_clip`` dependency is not installed.
+
+    References:
+    ===========
+    [1] Alec Radford, Jong Wook Kim, Chris Hallacy, Aditya Ramesh, Gabriel Goh,
+        Sandhini Agarwal, Girish Sastry, Amanda Askell, Pamela Mishkin, Jack Clark,
+        Gretchen Krueger, and Ilya Sutskever, "Learning Transferable Visual Models
+        From Natural Language Supervision," in Proc. ICML, PMLR 139, pp. 8748–8763,
+        2021.
+
+    [2] Gabriel Ilharco, Mitchell Wortsman, Ross Wightman, Cade Gordon, Nicholas
+        Carlini, Rohan Taori, Achal Dave, Vaishaal Shankar, Hongseok Namkoong,
+        John Miller, Hannaneh Hajishirzi, Ali Farhadi, and Ludwig Schmidt,
+        "OpenCLIP," Zenodo, Jul. 2021.
+        doi: 10.5281/zenodo.5143773
+    """
+
+    #: Keys a serialised state must contain to be a valid encoder file.
+    _STATE_KEYS = frozenset(
+        {
+            "encoder_class",
+            "similarity_func",
+            "model_name",
+            "pretrained",
+            "normalize",
+        }
+    )
+
+    def __init__(
+        self,
+        model_name: str = "ViT-B-32",
+        pretrained: str | None = "laion2b_s34b_b79k",
+        *,
+        device: str | None = None,
+        normalize: bool = True,
+        similarity_func: str = "cosine",
+    ) -> None:
+        _open_clip_import.check()
+        super().__init__(similarity_func=similarity_func)
+        self._model_name = model_name
+        self._pretrained = pretrained
+        self._normalize = normalize
+        self._device = _resolve_device(device)
+        model, _, preprocess = open_clip.create_model_and_transforms(
+            model_name, pretrained=pretrained, device=self._device
+        )
+        model.eval()
+        self._model = model
+        self._preprocess = preprocess
+
+    @property
+    def model_name(self) -> str:
+        """The `open_clip` architecture name (e.g. ``"ViT-B-32"``)."""
+        return self._model_name
+
+    @property
+    def pretrained(self) -> str | None:
+        """The `open_clip` pretrained weight tag (e.g. ``"laion2b_s34b_b79k"``)."""
+        return self._pretrained
+
+    @property
+    def device(self) -> str:
+        """The device the model runs on (``"cpu"`` or ``"cuda"``)."""
+        return self._device
+
+    @property
+    def normalize(self) -> bool:
+        """Whether the returned embeddings are L2-normalized."""
+        return self._normalize
+
+    @staticmethod
+    def _to_pil(image: UInt8NumpyArray) -> Image.Image:
+        """
+        Convert a canonical ``uint8`` image array into a PIL image.
+
+        The `open_clip` preprocessing transform converts the image to RGB, so a
+        grayscale ``(H, W)`` array is accepted as well as an ``(H, W, C)`` one.
+
+        :param image: A ``uint8`` array of shape ``(H, W)`` or ``(H, W, C)``.
+        :return: The corresponding :class:`PIL.Image.Image`.
+        """
+        return Image.fromarray(image)
+
+    def encode(
+        self,
+        images: ImageInput,
+        *,
+        dims: str = "HWC",
+        value_range: tuple[float, float] = (0.0, 255.0),
+    ) -> Float32NumpyArray:
+        """
+        Encode one or more images into CLIP embeddings.
+
+        Each image is normalized to a canonical ``uint8`` ``(H, W, C)`` array,
+        converted to a PIL image, passed through the `open_clip` preprocessing
+        transform and the image tower of the model. When ``normalize`` is set,
+        the embeddings are L2-normalized.
+
+        :param images: A single ``MatLike`` image, a batched array, or an
+            iterable of images. Consider using an iterator for large datasets.
+        :param dims: Axis-label string, one character per array axis in order:
+            ``"H"`` = height (rows), ``"W"`` = width (columns), ``"C"`` = channels
+            (e.g. RGB), ``"B"`` = batch size. For example, ``"HWC"`` is height ×
+            width × channels (NumPy/OpenCV single-image layout, **default**);
+            ``"CHW"`` is channels × height × width (PyTorch single-image layout);
+            ``"BCHW"`` is batch × channels × height × width (PyTorch batched layout).
+            See :mod:`pyvisim.typing`.
+        :param value_range: The ``(low, high)`` range the input values live in;
+            converted into the canonical ``[0, 255]`` range.
+        :return: ``(N, D)`` array holding one ``D``-dimensional embedding per
+            input image.
+        """
+        embeddings: list[Float32NumpyArray] = []
+        for image in iter_images(images, dims=dims, value_range=value_range):
+            tensor = self._preprocess(self._to_pil(image)).unsqueeze(0).to(self._device)
+            with torch.no_grad():
+                features = self._model.encode_image(tensor)
+            if self._normalize:
+                features = features / features.norm(dim=-1, keepdim=True)
+            embeddings.append(
+                np.asarray(features.detach().cpu().numpy(), dtype=np.float32)
+            )
+        return np.vstack(embeddings)
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialise this encoder into a JSON-safe state dictionary.
+
+        Only the identifiers needed to rebuild the encoder are stored; the
+        pretrained weights are re-downloaded by `open_clip` on :meth:`from_dict`.
+
+        :return: A JSON-safe encoder description suitable for :meth:`from_dict`.
+        """
+        return {
+            "format_version": _CLIP_ENCODER_FILE_FORMAT_VERSION,
+            "encoder_class": type(self).__name__,
+            "model_name": self._model_name,
+            "pretrained": self._pretrained,
+            "normalize": self._normalize,
+            "device": self._device,
+            "similarity_func": self._similarity_func_name,
+        }
+
+    @classmethod
+    def from_dict(cls, state: dict[str, Any]) -> "CLIPEncoder":
+        """
+        Rebuild a :class:`CLIPEncoder` from a dictionary produced by :meth:`to_dict`.
+
+        :param state: A JSON-safe encoder description from :meth:`to_dict`.
+        :return: A ready-to-use encoder instance.
+        """
+        return cls(
+            model_name=state["model_name"],
+            pretrained=state["pretrained"],
+            device=state.get("device"),
+            normalize=state["normalize"],
+            similarity_func=state["similarity_func"],
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(model_name={self._model_name}, "
+            f"pretrained={self._pretrained}, device={self._device}, "
+            f"normalize={self._normalize}, "
+            f"similarity_func={self.similarity_func_name})"
+        )

--- a/pyvisim/lazy_import/__init__.py
+++ b/pyvisim/lazy_import/__init__.py
@@ -1,0 +1,7 @@
+"""Lazy-import helpers for pyvisim's optional dependencies."""
+
+from .lazy_import import OptionalImport
+
+__all__ = [
+    "OptionalImport",
+]

--- a/pyvisim/lazy_import/lazy_import.py
+++ b/pyvisim/lazy_import/lazy_import.py
@@ -1,0 +1,86 @@
+"""Utilities for deferring the import errors of optional dependencies.
+
+This lets :mod:`pyvisim` advertise heavyweight extras (such as
+``transformers``) without forcing every user to install them. The import is
+attempted eagerly, but if the dependency is missing the resulting
+:class:`ImportError` is captured and only re-raised when the dependent code is
+actually used.
+"""
+
+from __future__ import annotations
+
+from types import TracebackType
+
+
+class OptionalImport:
+    """Defer the :class:`ImportError` of an optional dependency.
+
+    Use as a context manager around the imports of an optional dependency. If
+    the dependency is installed, the imports run normally. If it is missing,
+    the error is swallowed and stored, then re-raised with an actionable
+    message the first time :meth:`check` is called.
+
+    :param package: Import name of the optional dependency, e.g. ``"transformers"``.
+    :param extra: Name of the pip/uv extra that installs it, e.g. ``"neural"``.
+
+    :Example:
+
+    .. code-block:: python
+
+        with OptionalImport(package="transformers", extra="neural") as _import:
+            from transformers import AutoModel
+
+        class Encoder:
+            def __init__(self) -> None:
+                _import.check()  # raises here if transformers is missing
+    """
+
+    def __init__(self, *, package: str, extra: str) -> None:
+        self._package = package
+        self._extra = extra
+        self._error: ImportError | None = None
+
+    def __enter__(self) -> OptionalImport:
+        """Enter the context manager.
+
+        :returns: This instance, so it can be bound with ``as``.
+        """
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        """Capture an :class:`ImportError` raised inside the ``with`` block.
+
+        :param exc_type: Type of the raised exception, if any.
+        :param exc_value: The raised exception instance, if any.
+        :param traceback: The associated traceback, if any.
+        :returns: ``True`` to suppress a captured :class:`ImportError`;
+            ``False`` so any unrelated exception propagates normally.
+        """
+        if isinstance(exc_value, ImportError):
+            self._error = exc_value
+            return True
+        return False
+
+    @property
+    def is_available(self) -> bool:
+        """Whether the optional dependency imported successfully.
+
+        :returns: ``True`` if the dependency is installed, ``False`` otherwise.
+        """
+        return self._error is None
+
+    def check(self) -> None:
+        """Re-raise the deferred import error with an actionable message.
+
+        :raises ImportError: If the optional dependency failed to import.
+        """
+        if self._error is not None:
+            raise ImportError(
+                f"To use this feature, you need to install the optional dependency '{self._package}'. "
+                f"Install it with: 'uv pip install \"pyvisim[{self._extra}]\"' or 'pip install \"pyvisim[{self._extra}]\"'"
+            ) from self._error

--- a/tests/encoders/clip/test_clip.py
+++ b/tests/encoders/clip/test_clip.py
@@ -1,0 +1,231 @@
+"""Behavioural and serialization tests for :class:`pyvisim.encoders.CLIPEncoder`.
+
+These tests build the encoder with the fixed pretrained ``openai`` ViT-B-32
+weights, so encodings are reproducible across runs and instances (which lets the
+save/load test assert identical encodings). Loading the weights downloads
+~338 MB on first run and is cached afterwards, so the whole module is marked
+``slow`` and is deselected by ``make test-unit`` (``-m "not slow"``).
+
+Weight-free logic (device resolution and the lazy import guard) lives in
+``test_clip_unit.py`` and runs in the fast suite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+from pyvisim.encoders import CLIPEncoder, VLADEncoder
+
+if TYPE_CHECKING:
+    from tests.conftest import ImageObj
+
+#: Every test in this module downloads/loads real CLIP weights.
+pytestmark = pytest.mark.slow
+
+#: Fixed pretrained weight tag used for reproducible encodings.
+#: `openai` weights are a little lighter compared to the default
+#: laion2b_s34b_b79k weights, so this is used instead to make the
+#: test faster
+PRETRAINED = "openai"
+#: Joint embedding dimension of the ``ViT-B-32`` architecture.
+EMBED_DIM = 512
+
+
+@pytest.fixture(scope="module")
+def clip_encoder() -> CLIPEncoder:
+    """A ``CLIPEncoder`` with the fixed pretrained ``openai`` ViT-B-32 weights.
+
+    Module-scoped so the weights are loaded only once for the whole module.
+
+    :returns: a ready-to-use ``CLIPEncoder``.
+    """
+    return CLIPEncoder(pretrained=PRETRAINED)
+
+
+# §1 encode behaviour
+
+
+def test_encode_returns_one_row_per_image(
+    clip_encoder: CLIPEncoder, rgb_image: ImageObj, checkerboard_image: ImageObj
+) -> None:
+    """Encoding a batch yields one ``EMBED_DIM`` embedding per input image."""
+    embeddings = clip_encoder.encode([rgb_image.array, checkerboard_image.array])
+    assert embeddings.shape == (2, EMBED_DIM)
+    assert embeddings.dtype == np.float32
+
+
+def test_encode_accepts_single_image(
+    clip_encoder: CLIPEncoder, rgb_image: ImageObj
+) -> None:
+    """A single (un-batched) image encodes to a ``(1, EMBED_DIM)`` array."""
+    embeddings = clip_encoder.encode(rgb_image.array)
+    assert embeddings.shape == (1, EMBED_DIM)
+
+
+def test_encode_embeddings_are_normalized_by_default(
+    clip_encoder: CLIPEncoder, rgb_image: ImageObj, grayscale_image: ImageObj
+) -> None:
+    """With ``normalize=True`` every embedding has unit L2 norm."""
+    embeddings = clip_encoder.encode([rgb_image.array, grayscale_image.array])
+    norms = np.linalg.norm(embeddings, axis=1)
+    assert np.allclose(norms, 1.0, atol=1e-5)
+
+
+def test_encode_without_normalization_keeps_raw_magnitude(
+    rgb_image: ImageObj,
+) -> None:
+    """With ``normalize=False`` embeddings are not forced to unit norm."""
+    encoder = CLIPEncoder(pretrained=PRETRAINED, normalize=False)
+    embeddings = encoder.encode(rgb_image.array)
+    norms = np.linalg.norm(embeddings, axis=1)
+    assert not np.allclose(norms, 1.0, atol=1e-3)
+
+
+def test_encode_is_reproducible(clip_encoder: CLIPEncoder, rgb_image: ImageObj) -> None:
+    """Encoding the same image twice yields identical embeddings."""
+    first = clip_encoder.encode(rgb_image.array)
+    second = clip_encoder.encode(rgb_image.array)
+    assert np.array_equal(first, second)
+
+
+def test_encode_grayscale_and_rgb_share_embedding_dim(
+    clip_encoder: CLIPEncoder, grayscale_image: ImageObj, rgb_image: ImageObj
+) -> None:
+    """Grayscale and RGB inputs both yield ``EMBED_DIM`` embeddings.
+
+    The open_clip preprocessing transform converts any input to RGB, so a
+    single-channel ``(H, W)`` image (passed with ``dims="HW"``) is accepted just
+    like an ``(H, W, C)`` one.
+    """
+    gray = clip_encoder.encode(grayscale_image.array, dims="HW")
+    rgb = clip_encoder.encode(rgb_image.array)
+    assert gray.shape == rgb.shape == (1, EMBED_DIM)
+
+
+# §2 similarity
+
+
+def test_default_similarity_func_is_cosine(clip_encoder: CLIPEncoder) -> None:
+    """The encoder defaults to the cosine similarity metric."""
+    assert clip_encoder.similarity_func_name == "cosine"
+
+
+def test_similarity_score_identical_images_is_one(
+    clip_encoder: CLIPEncoder, rgb_image: ImageObj
+) -> None:
+    """An image is maximally cosine-similar to itself."""
+    score = clip_encoder.similarity_score(rgb_image.array, rgb_image.array)
+    assert score.shape == (1, 1)
+    assert np.isclose(score[0, 0], 1.0, atol=1e-5)
+
+
+def test_shifted_image_more_similar_than_completely_different(
+    clip_encoder: CLIPEncoder,
+    checkerboard_image: ImageObj,
+    horizontal_gradient_image: ImageObj,
+) -> None:
+    """A one-pixel shift scores higher than a completely different image.
+
+    A checkerboard and its one-pixel-shifted copy share almost all of their
+    content, so they must score more similar than the checkerboard against a
+    structurally different gradient image. All three are single-channel
+    ``(H, W)`` images, so ``dims="HW"`` is passed.
+    """
+    shifted = np.roll(checkerboard_image.array, shift=1, axis=1)
+    shifted_score = clip_encoder.similarity_score(
+        checkerboard_image.array, shifted, dims="HW"
+    )
+    different_score = clip_encoder.similarity_score(
+        checkerboard_image.array, horizontal_gradient_image.array, dims="HW"
+    )
+    assert shifted_score[0, 0] > different_score[0, 0]
+
+
+# §3 configuration, properties and repr
+
+
+def test_properties_reflect_constructor_arguments() -> None:
+    """The read-only properties expose the configured values."""
+    encoder = CLIPEncoder(
+        pretrained=PRETRAINED, normalize=False, similarity_func="euclidean"
+    )
+    assert encoder.model_name == "ViT-B-32"
+    assert encoder.pretrained == PRETRAINED
+    assert encoder.normalize is False
+    assert encoder.similarity_func_name == "euclidean"
+    assert encoder.device in {"cpu", "cuda"}
+
+
+def test_repr_names_class_and_model(clip_encoder: CLIPEncoder) -> None:
+    """``repr`` names the encoder class and its model architecture."""
+    text = repr(clip_encoder)
+    assert "CLIPEncoder(" in text
+    assert "model_name=ViT-B-32" in text
+
+
+# §4 serialization
+
+
+def test_to_dict_contains_required_state_keys(clip_encoder: CLIPEncoder) -> None:
+    """``to_dict`` emits every key required to validate and rebuild the file."""
+    state = clip_encoder.to_dict()
+    assert clip_encoder._STATE_KEYS.issubset(state)
+    assert state["encoder_class"] == "CLIPEncoder"
+
+
+def test_from_dict_roundtrips_configuration(clip_encoder: CLIPEncoder) -> None:
+    """``from_dict(to_dict())`` restores the encoder configuration."""
+    restored = CLIPEncoder.from_dict(clip_encoder.to_dict())
+    assert restored.model_name == clip_encoder.model_name
+    assert restored.pretrained == clip_encoder.pretrained
+    assert restored.normalize == clip_encoder.normalize
+    assert restored.similarity_func_name == clip_encoder.similarity_func_name
+
+
+def test_save_appends_suffix(clip_encoder: CLIPEncoder, tmp_path: Path) -> None:
+    """Saving appends the ``.encoder`` suffix and writes the file."""
+    path = clip_encoder.save_to_disk(tmp_path / "clip")
+    assert str(path).endswith(".encoder")
+    assert path.exists()
+
+
+def test_save_load_produces_identical_encodings(
+    clip_encoder: CLIPEncoder, tmp_path: Path, rgb_image: ImageObj
+) -> None:
+    """A saved-and-reloaded encoder produces the same encodings.
+
+    With fixed pretrained weights the reconstructed model is identical, so the
+    encodings must match exactly (up to float tolerance).
+    """
+    path = clip_encoder.save_to_disk(tmp_path / "clip")
+    loaded = CLIPEncoder.load_from_disk(path)
+    assert np.allclose(
+        loaded.encode(rgb_image.array),
+        clip_encoder.encode(rgb_image.array),
+        atol=1e-5,
+    )
+
+
+def test_load_invalid_file_raises(tmp_path: Path) -> None:
+    """Loading a file that is not a valid encoder raises ``ValueError``."""
+    bad = tmp_path / "bad.encoder"
+    bad.write_bytes(b"not a safetensors file")
+    with pytest.raises(ValueError, match="not a valid .encoder file"):
+        CLIPEncoder.load_from_disk(bad)
+
+
+def test_load_with_incompatible_encoder_raises(
+    clip_encoder: CLIPEncoder, tmp_path: Path
+) -> None:
+    """A CLIP file is rejected by an encoder expecting different state keys.
+
+    A ``VLADEncoder`` requires clustering-specific keys that a CLIP file does
+    not carry, so the file fails validation before any class-name check.
+    """
+    path = clip_encoder.save_to_disk(tmp_path / "clip")
+    with pytest.raises(ValueError, match="not a valid .encoder file"):
+        VLADEncoder.load_from_disk(path)

--- a/tests/encoders/clip/test_clip_unit.py
+++ b/tests/encoders/clip/test_clip_unit.py
@@ -1,0 +1,57 @@
+"""Fast unit tests for :class:`pyvisim.encoders.CLIPEncoder`.
+
+These exercise logic that needs no model weights, so they stay in the fast
+suite: device resolution and the lazy optional-dependency guard.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from pyvisim.encoders import CLIPEncoder
+from pyvisim.encoders import clip as clip_module
+from pyvisim.lazy_import import OptionalImport
+
+# §1 device resolution
+
+
+def test_resolve_device_falls_back_to_cpu_without_cuda(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without CUDA, both auto-select and an explicit request yield ``cpu``."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    assert clip_module._resolve_device(None) == "cpu"
+    assert clip_module._resolve_device("cuda") == "cpu"
+    assert clip_module._resolve_device("cpu") == "cpu"
+
+
+def test_resolve_device_prefers_cuda_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With CUDA available, auto-select and an explicit request yield ``cuda``."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    assert clip_module._resolve_device(None) == "cuda"
+    assert clip_module._resolve_device("cuda") == "cuda"
+
+
+# §2 lazy optional-dependency guard
+
+
+def test_missing_open_clip_raises_actionable_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Constructing a ``CLIPEncoder`` without open_clip raises a helpful error.
+
+    open_clip is installed in the test environment, so a missing dependency is
+    simulated by swapping the module-level :class:`OptionalImport` for one whose
+    import failed. The constructor must surface the ``pip install`` hint and not
+    attempt to build a model.
+    """
+    broken = OptionalImport(package="open_clip_torch", extra="nn")
+    with broken:
+        import pyvisim_missing_open_clip_dependency  # type: ignore[import-not-found] # noqa: F401
+    assert not broken.is_available
+    monkeypatch.setattr(clip_module, "_open_clip_import", broken)
+    with pytest.raises(ImportError, match=r"pyvisim\[nn\]"):
+        CLIPEncoder()


### PR DESCRIPTION
### Related Issues

- fixes #69 

### Proposed Changes:

This adds a new `CLIPEncoder` that turns images into CLIP embeddings, plus the
plumbing to keep its heavyweight dependency optional.

`CLIPEncoder` is an `ImageEncoderBase` subclass (CLIP encodes images end-to-end,
so it needs no feature extractor or clustering model). On construction it loads a
pretrained `open_clip` model and its matching preprocessing transform; `encode`
runs each image through the model's image tower and, by default, L2-normalizes
the result so the embeddings drop straight into cosine/dot-product search. It
plugs into the existing machinery for free — `similarity_score`, `save_to_disk`/
`load_from_disk`, and the `Encoder` protocol all work unchanged.

`open_clip` is large and not everyone wants it, so:

- I added a `nn` extra (`pip install "pyvisim[nn]"`) that pulls in
  `open_clip_torch`.
- The import is deferred through the new lazy-import mechanism. `open_clip` is
  imported inside an `OptionalImport` context at module load, the `ImportError`
  is swallowed if it's missing, and it's only re-raised — with an actionable
  `pip install "pyvisim[nn]"` hint — when someone actually constructs a
  `CLIPEncoder`. Importing `pyvisim` (or any other encoder) never requires it.
  This also promotes `pyvisim/lazy_import/` to a real, importable package.

For serialization I deliberately store only the identifiers needed to rebuild the
encoder (`model_name`, the `pretrained` tag, `normalize`, `device`,
`similarity_func`) rather than the weights — same philosophy as the bundled
torchvision backbones. `open_clip` re-fetches the pretrained weights on load, so
`.encoder` files stay tiny and a reloaded encoder reproduces the original
encodings exactly.

Device handling mirrors `DeepConvFeature`: it auto-selects CUDA when available
and gracefully falls back to CPU (including when a file saved with `device="cuda"`
is loaded on a CPU-only machine).

### How did you test it?

New tests under `tests/encoders/clip/`:

- `test_clip.py` — behavioural and serialization tests built on the fixed
  pretrained `openai` ViT-B-32 weights so encodings are reproducible: encode
  shape/dtype, default L2 normalization (and the `normalize=False` path),
  grayscale vs RGB handling via `dims`, a shift-vs-completely-different cosine
  ordering check, `to_dict`/`from_dict`, and a save/load roundtrip asserting
  identical encodings. These download weights (~338 MB, cached) so the module is
  marked `slow` and is skipped by `make test-unit`.
- `test_clip_unit.py` — fast, weight-free tests for device resolution and the
  lazy import guard (simulating a missing `open_clip` and asserting the
  actionable error).

`make fmt` is clean. All 20 CLIP tests pass locally (17 slow + 3 fast).

### Notes for the reviewer

- The serialization-stores-identifiers-not-weights decision is the main thing
  worth a look — it keeps `.encoder` files small but means loading requires
  network access (or a populated `open_clip`/HF cache) to fetch the weights.
- `pretrained=None` is accepted to build randomly-initialized weights with no
  download; the test suite uses the fixed `openai` tag instead for
  reproducibility.
- Heads up, unrelated to this PR: `make test-types` currently fails on a
  pre-existing numpy/mypy incompatibility — numpy 2.5 ships PEP 695 `type`
  statements in its stubs that mypy won't parse under the configured
  `python_version = "3.10"`. It fails the same way on untouched files (e.g.
  `vlad.py`). The CLIP code itself is type-clean (mypy reports no issues when
  parsed as 3.12). I left it alone to keep this PR scoped to CLIP.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] When applicable: I have reviewed the AI-generated code sections, according to [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#using-ai-to-contribute).
- [x] I have run [pre-commit hooks](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#set-up-developer-environment) and fixed any issue.
