### PR TITLE
Feat/lazy import modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Install dependencies
-        run: uv sync --group types
+        run: uv sync --group types --extra nn
 
       - name: Run mypy
         run: uv run --group types mypy pyvisim/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Install dependencies
-        run: uv sync --group types --extra nn
+        run: uv sync --group types --extra nn --extra search
 
       - name: Run mypy
         run: uv run --group types mypy pyvisim/
@@ -86,7 +86,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Install dependencies
-        run: uv sync --group test --extra nn
+        run: uv sync --group test --extra nn --extra search
 
       - name: Run pytest with coverage
         run: uv run --group test pytest -m "not slow"
@@ -115,7 +115,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Install dependencies
-        run: uv sync --group test --extra nn
+        run: uv sync --group test --extra nn --extra search
 
       - name: Run slow tests
         run: uv run --group test pytest -m "slow"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,23 @@
 
   Saving stores only the model identifiers (`model_name`, `pretrained` tag, etc.), not
   the weights, so `.encoder` files stay tiny and open_clip re-fetches the weights on load.
-- `nn` optional extra (`pip install "pyvisim[nn]"`) that pulls in `open_clip_torch` for
-  the neural-network encoders. open_clip is imported lazily, so importing `pyvisim` never
-  requires it; you only hit the error (with an install hint) when you build a
-  `CLIPEncoder` without it installed.
+- `nn` optional extra (`pip install "pyvisim[nn]"`) now pulls in the whole deep-learning
+  stack: `torch`, `torchvision`, `torchaudio` and `open_clip_torch`. It covers
+  `DeepConvFeature` (VGG16 deep features), `CLIPEncoder`, and the `datasets` and
+  `neural_networks` modules. Everything is imported lazily, so importing `pyvisim` never
+  requires it; you only hit the error (with an install hint) the first time you actually
+  build one of these without it installed.
+- `search` optional extra (`pip install "pyvisim[search]"`) that pulls in `faiss-cpu` for
+  the retrieval / image-store stack: `InMemoryImageEmbeddingStore`, `ImageRetriever` and
+  the `ImageIndex*` classes. faiss is imported lazily too, so you only need it when you
+  build a store or an index.
+
+### Breaking
+- ⚠️ `pip install pyvisim` no longer installs torch or faiss. The base install now covers
+  the SIFT/RootSIFT encoders only. Install `[nn]` for deep features and CLIP, `[search]`
+  for the image store and retrieval, or `pip install "pyvisim[nn,search]"` for everything.
+  Heads up: the VGG16 pretrained encoders (`OXFORD102_K256_VGG16*`) build a
+  `DeepConvFeature`, so they now need the `nn` extra.
 
 ## [0.6.0] - 2026-06-20
 

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 .PHONY: test-types test-unit fmt
 
-# Strict mypy type-checking
+# Strict mypy type-checking (the 'nn' extra installs torch for type-checking)
 test-types:
-	uv run --group types mypy pyvisim/
+	uv run --group types --extra nn mypy pyvisim/
 
 # Unit tests with a terminal coverage report (skips slow, weight-downloading tests)
 test-unit:
-	uv run --group test pytest -m "not slow"
+	uv run --group test --extra nn pytest -m "not slow"
 
 # Test slow tests
 test-slow:
-	uv run --group test pytest -m slow
+	uv run --group test --extra nn pytest -m slow
 # Formatting with ruff
 fmt:
 	uv run --group fmt ruff check --fix .

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 .PHONY: test-types test-unit fmt
 
-# Strict mypy type-checking (the 'nn' extra installs torch for type-checking)
+# Strict mypy type-checking ('nn' installs torch; 'search' installs faiss)
 test-types:
-	uv run --group types --extra nn mypy pyvisim/
+	uv run --group types --extra nn --extra search mypy pyvisim/
 
 # Unit tests with a terminal coverage report (skips slow, weight-downloading tests)
 test-unit:
-	uv run --group test --extra nn pytest -m "not slow"
+	uv run --group test --extra nn --extra search pytest -m "not slow"
 
 # Test slow tests
 test-slow:
-	uv run --group test --extra nn pytest -m slow
+	uv run --group test --extra nn --extra search pytest -m slow
 # Formatting with ruff
 fmt:
 	uv run --group fmt ruff check --fix .

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ have any suggestions or questions!
    - Use encoding methods like VLAD or Fisher Vectors to quickly find the most relevant matches. Please visit
    [this juptyer notebook](https://github.com/MechaCritter/Python-Visual-Similarity-Examples/blob/master/notebooks/vlad_and_fisher_with_vgg16_deep_features.ipynb) for an example.
    - For large galleries, build an `InMemoryImageEmbeddingStore` over your image paths;
-     it indexes the embeddings and searches them for you:
+     it indexes the embeddings and searches them for you (needs the `search` extra:
+     `pip install "pyvisim[search]"`):
 
      ```python
      from pyvisim.image_store import InMemoryImageEmbeddingStore
@@ -108,7 +109,9 @@ have any suggestions or questions!
 2. **Deep Learning Embeddings**  
    - Generate VLAD or Fisher vectors from neural network embeddings, e.g., VGG16 or other models.
    - Enhance your deep learning pipeline by leveraging traditional encoding methods on top of CNN features.
-   - Or skip the aggregation entirely and use `CLIPEncoder` for ready-made CLIP embeddings (`pip install "pyvisim[nn]"`).
+   - Or skip the aggregation entirely and use `CLIPEncoder` for ready-made CLIP embeddings.
+   - The VGG16 deep-feature path (`DeepConvFeature`) and `CLIPEncoder` both need the `nn`
+   extra: `pip install "pyvisim[nn]"`.
 
 3. **Image Clustering**  
    - Cluster images based on their similarities to group them by category or content. An example and benchmarking
@@ -128,13 +131,13 @@ have any suggestions or questions!
 To use the library, you can simply install it via pip:
 
 ```bash
-pip install pyvisim
-```
-
-If you want to use the `CLIPEncoder`, you need to install the `nn` extra:
-
 ```bash
+pip install pyvisim
+# For deep learning features and the OxfordFlowerDataset
 pip install "pyvisim[nn]"
+# For image search feature
+pip install "pyvisim[search]"
+```
 ```
 
 or clone the repository and install it locally:
@@ -172,6 +175,9 @@ from pyvisim.encoders import (
 vlad = VLADEncoder.from_pretrained(PretrainedVLAD.OXFORD102_K256_ROOTSIFT)
 fisher = FisherVectorEncoder.from_pretrained(PretrainedFisher.OXFORD102_K256_VGG16_PCA)
 ```
+
+The SIFT/RootSIFT variants work on the base install. The `*_VGG16*` variants build a
+`DeepConvFeature`, so they need the `nn` extra: `pip install "pyvisim[nn]"`.
 
 All clustering models were trained with `k=256`. The choice of `k` was made arbitrarily
 based on the paper <sup>[5](#references)</sup>, where the authors tested with `k=32`, `64`, `128`, `256`, `512`, and so on.

--- a/docs/encoders/README.md
+++ b/docs/encoders/README.md
@@ -22,7 +22,8 @@ pass at construction, then fit it in `learn`. Trained encoders are saved and
 restored with `save_to_disk` / `load_from_disk`; the older pretrained-weight enums
 in [weights.md](weights.md) still work but are deprecated. `CLIPEncoder` skips the
 `learn` step entirely (its weights are already pretrained) and needs the `nn`
-extra: `pip install "pyvisim[nn]"`.
+extra: `pip install "pyvisim[nn]"`. The same extra is required for the VGG16
+`DeepConvFeature` extractor.
 
 ## VLAD vs Fisher Vector
 

--- a/docs/features/deep_conv_feature.md
+++ b/docs/features/deep_conv_feature.md
@@ -2,6 +2,10 @@
 
 File: [`_features.py`](../../pyvisim/features/_features.py)
 
+> [!NOTE]
+> Requires extra: `nn` (`pip install "pyvisim[nn]"`)
+
+
 Extracts local descriptors from the convolutional feature map of a neural network
 (default VGG16). Each spatial location in the chosen conv layer becomes one descriptor,
 giving a CNN-based alternative to SIFT that plugs into the same encoders.

--- a/docs/image_store.md
+++ b/docs/image_store.md
@@ -3,6 +3,9 @@
 File: [`pyvisim/image_store/__init__.py`](../pyvisim/image_store/__init__.py)
 (Implementation: [`pyvisim/image_store/image_store.py`](../pyvisim/image_store/image_store.py))
 
+> [!NOTE]
+> Requires extra: `search` (`pip install "pyvisim[search]"`)
+
 `InMemoryImageEmbeddingStore` is the gallery object the retrieval pipeline is built
 around. You give it a list of image paths, an encoder, and the kind of index you want;
 it encodes every image, builds a FAISS index over the embeddings, and from then on you

--- a/docs/retrieval/README.md
+++ b/docs/retrieval/README.md
@@ -2,6 +2,9 @@
 
 File: [`pyvisim/retrieval/__init__.py`](../../pyvisim/retrieval/__init__.py)
 
+> [!NOTE]
+> Requires extra: `search` (`pip install "pyvisim[search]"`)
+
 The `retrieval` package finds the images in a gallery that look most like a query
 image. The gallery is an
 [`InMemoryImageEmbeddingStore`](../image_store.md), which builds a FAISS index over

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,6 @@ dependencies = [
     "safetensors",
     "scikit-learn",
     "scipy",
-    "torch",
-    "torchvision",
-    "torchaudio",
     "tqdm",
     "requests",
     "faiss-cpu",
@@ -45,8 +42,13 @@ dependencies = [
 
 # Optional extras. Install with e.g. 'pip install "pyvisim[nn]"'.
 [project.optional-dependencies]
-# Neural-network encoders (e.g. CLIPEncoder) built on top of open_clip.
+# Deep-learning features and encoders (DeepConvFeature, CLIPEncoder, the
+# datasets and neural_networks modules) built on top of torch / torchvision /
+# open_clip.
 nn = [
+    "torch",
+    "torchvision",
+    "torchaudio",
     "open_clip_torch",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "scipy",
     "tqdm",
     "requests",
-    "faiss-cpu",
 ]
 
 # To install PyTorch with CUDA support instead of the CPU-only default:
@@ -50,6 +49,11 @@ nn = [
     "torchvision",
     "torchaudio",
     "open_clip_torch",
+]
+# Accelerated nearest-neighbour search and retrieval (ImageIndex,
+# InMemoryImageEmbeddingStore, ImageRetriever) built on top of faiss.
+search = [
+    "faiss-cpu",
 ]
 
 [project.urls]

--- a/pyvisim/_utils.py
+++ b/pyvisim/_utils.py
@@ -2,10 +2,10 @@ from typing import cast
 
 import cv2
 import numpy as np
-import torch
 from sklearn.metrics.pairwise import cosine_similarity as cs
 from sklearn.metrics.pairwise import euclidean_distances, manhattan_distances
 
+from .lazy_import import is_tensor
 from .typing import (
     Float64NumpyArray,
     FloatNumpyArray,
@@ -38,7 +38,7 @@ def _as_2d_array(value: FloatNumpyArray) -> FloatNumpyArray:
     :param value: A NumPy array or a torch tensor.
     :return: A 2-D NumPy array of shape ``(N, D)``.
     """
-    if isinstance(value, torch.Tensor):
+    if is_tensor(value):
         value = value.cpu().numpy()
     return value.reshape(1, -1) if value.ndim == 1 else value
 

--- a/pyvisim/datasets/datasets.py
+++ b/pyvisim/datasets/datasets.py
@@ -12,10 +12,6 @@ from pyvisim._utils import read_image_rgb
 from pyvisim.lazy_import import OptionalImport
 from pyvisim.typing import UInt8NumpyArray
 
-# OxfordFlowerDataset subclasses torch.utils.data.Dataset, so torch and
-# torchvision (the ``nn`` extra) are required to even define it. They are
-# imported lazily so importing pyvisim never requires them; importing this
-# module raises an actionable ImportError when they are missing.
 with OptionalImport(package="torch", extra="nn") as _torch_import:
     from torch.utils.data import Dataset
     from torchvision import transforms

--- a/pyvisim/datasets/datasets.py
+++ b/pyvisim/datasets/datasets.py
@@ -5,13 +5,22 @@ from multiprocessing import Process
 import requests
 import scipy
 from platformdirs import user_cache_dir
-from torch.utils.data import Dataset
-from torchvision import transforms
 from tqdm import tqdm
 
 from pyvisim._config import setup_logging
 from pyvisim._utils import read_image_rgb
+from pyvisim.lazy_import import OptionalImport
 from pyvisim.typing import UInt8NumpyArray
+
+# OxfordFlowerDataset subclasses torch.utils.data.Dataset, so torch and
+# torchvision (the ``nn`` extra) are required to even define it. They are
+# imported lazily so importing pyvisim never requires them; importing this
+# module raises an actionable ImportError when they are missing.
+with OptionalImport(package="torch", extra="nn") as _torch_import:
+    from torch.utils.data import Dataset
+    from torchvision import transforms
+
+_torch_import.check()
 
 setup_logging()
 

--- a/pyvisim/encoders/clip.py
+++ b/pyvisim/encoders/clip.py
@@ -10,7 +10,6 @@ requires it: the actionable :class:`ImportError` is raised only when a
 from typing import Any
 
 import numpy as np
-import torch
 from PIL import Image
 
 from .._config import setup_logging
@@ -18,6 +17,12 @@ from ..lazy_import import OptionalImport
 from ..typing import Float32NumpyArray, ImageInput, UInt8NumpyArray
 from ._base_encoder import ImageEncoderBase
 from .utils import iter_images
+
+with OptionalImport(package="torch", extra="nn") as _torch_import:
+    import torch
+
+_torch_import.check()
+
 
 with OptionalImport(package="open_clip_torch", extra="nn") as _open_clip_import:
     import open_clip

--- a/pyvisim/encoders/clip.py
+++ b/pyvisim/encoders/clip.py
@@ -21,9 +21,6 @@ from .utils import iter_images
 with OptionalImport(package="torch", extra="nn") as _torch_import:
     import torch
 
-_torch_import.check()
-
-
 with OptionalImport(package="open_clip_torch", extra="nn") as _open_clip_import:
     import open_clip
 
@@ -110,6 +107,7 @@ class CLIPEncoder(ImageEncoderBase):
         normalize: bool = True,
         similarity_func: str = "cosine",
     ) -> None:
+        _torch_import.check()
         _open_clip_import.check()
         super().__init__(similarity_func=similarity_func)
         self._model_name = model_name

--- a/pyvisim/encoders/utils.py
+++ b/pyvisim/encoders/utils.py
@@ -1,10 +1,10 @@
 from collections.abc import Iterable, Iterator
 
 import numpy as np
-import torch
 
 from .._errors import InvalidImageError
 from ..features._utils import grayscale_dims
+from ..lazy_import import is_tensor
 from ..typing import ImageInput, UInt8NumpyArray, _to_image_list
 
 
@@ -34,11 +34,11 @@ def iter_images(
     :return: An iterator over ``uint8`` images of shape ``(H, W[, C])``.
     :raises InvalidImageError: If a string/bytes object is passed as an image.
     """
-    if not isinstance(images, (np.ndarray, torch.Tensor, Iterable)):
+    if not (isinstance(images, (np.ndarray, Iterable)) or is_tensor(images)):
         raise InvalidImageError(
             f"Expected image array(s), but got a {type(images).__name__} object."
         )
-    if isinstance(images, (np.ndarray, torch.Tensor)):
+    if isinstance(images, np.ndarray) or is_tensor(images):
         yield from _to_image_list(images, dims, value_range)
         return
     if isinstance(images, Iterable):

--- a/pyvisim/features/_deep_conv_feature.py
+++ b/pyvisim/features/_deep_conv_feature.py
@@ -12,9 +12,6 @@ from ..lazy_import import OptionalImport
 from ..typing import Float32NumpyArray, MatLike
 from ._utils import _check_output_shape, _to_single_image
 
-# torch and torchvision ship in the ``nn`` extra (``pip install "pyvisim[nn]"``)
-# and are imported lazily, so importing pyvisim never requires them. The
-# actionable ImportError is raised when a DeepConvFeature is constructed.
 with OptionalImport(package="torch", extra="nn") as _torch_import:
     import torch
     from torchvision import transforms

--- a/pyvisim/features/_deep_conv_feature.py
+++ b/pyvisim/features/_deep_conv_feature.py
@@ -1,18 +1,39 @@
+from __future__ import annotations
+
 import warnings
 from collections.abc import Callable
 from typing import Any
 
 import numpy as np
-import torch
-from torchvision import transforms
-from torchvision.models import VGG16_Weights, vgg16
 
 from .._base_classes import FeatureExtractorBase
 from .._config import setup_logging
+from ..lazy_import import OptionalImport
 from ..typing import Float32NumpyArray, MatLike
 from ._utils import _check_output_shape, _to_single_image
 
+# torch and torchvision ship in the ``nn`` extra (``pip install "pyvisim[nn]"``)
+# and are imported lazily, so importing pyvisim never requires them. The
+# actionable ImportError is raised when a DeepConvFeature is constructed.
+with OptionalImport(package="torch", extra="nn") as _torch_import:
+    import torch
+    from torchvision import transforms
+    from torchvision.models import VGG16_Weights, vgg16
+
 setup_logging()
+
+
+def _resolve_device(device: str | None) -> str:
+    """
+    Resolve a requested device, auto-selecting CUDA when available.
+
+    :param device: ``"cuda"``, ``"cpu"`` or ``None`` to auto-select.
+    :return: The chosen device string. ``None`` becomes ``"cuda"`` when a CUDA
+        device is available, otherwise ``"cpu"``.
+    """
+    if device is None:
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    return device
 
 
 #: Maps a backbone identifier to a builder. The builder takes a ``pretrained``
@@ -143,7 +164,8 @@ class DeepConvFeature(FeatureExtractorBase):
     :param layer_index: Which conv layer to hook (int). Use `list_conv_layers(...)`
                        to see the ordering or use -1 for the last conv layer.
     :param spatial_encoding: If True, appends (x/W, y/H) to each descriptor.
-    :param device: 'cpu' or 'cuda'. Where to run the model.
+    :param device: 'cpu' or 'cuda'. Where to run the model. Defaults to
+                   ``None``, which auto-selects 'cuda' when available, else 'cpu'.
     :param transform: Optional torchvision.transforms.Compose. Default includes `to_tensor`, `resize(224, 224)`,
                         and normalization with ImageNet stats.
 
@@ -166,11 +188,12 @@ class DeepConvFeature(FeatureExtractorBase):
         target_submodule: str | None = None,
         layer_index: int = -1,
         spatial_encoding: bool = True,
-        device: str = "cuda" if torch.cuda.is_available() else "cpu",
+        device: str | None = None,
         transform: transforms.Compose = None,
         **kwargs: Any,
     ):
         super().__init__()
+        _torch_import.check()
         backbone = self._resolve_deprecated_model(backbone, kwargs)
         # Track whether a rebuildable (torchvision-default) model is used: when
         # serialising, such a model is rebuilt from torchvision on load (no
@@ -181,7 +204,7 @@ class DeepConvFeature(FeatureExtractorBase):
         self._target_submodule = target_submodule
         self.layer_index = layer_index
         self.spatial_encoding = spatial_encoding
-        self.device = device
+        self.device = _resolve_device(device)
         self.transform = transform
         if self.transform is None:
             self.transform = transforms.Compose(
@@ -288,7 +311,7 @@ class DeepConvFeature(FeatureExtractorBase):
         return config
 
     @classmethod
-    def _from_config(cls, config: dict[str, Any]) -> "DeepConvFeature":
+    def _from_config(cls, config: dict[str, Any]) -> DeepConvFeature:
         """
         Rebuild a :class:`DeepConvFeature` from a serialised configuration.
 
@@ -301,7 +324,9 @@ class DeepConvFeature(FeatureExtractorBase):
         :return: A reconstructed deep feature extractor.
         :raises ValueError: If the stored model architecture is not known and
             cannot be rebuilt automatically.
+        :raises ImportError: If the optional torch dependency is not installed.
         """
+        _torch_import.check()
         arch = config["model_arch"]
         default_model = config.get("default_model", True)
         device = config.get("device", "cpu")

--- a/pyvisim/lazy_import/__init__.py
+++ b/pyvisim/lazy_import/__init__.py
@@ -1,7 +1,10 @@
 """Lazy-import helpers for pyvisim's optional dependencies."""
 
 from .lazy_import import OptionalImport
+from .torch_backend import is_tensor, torch_import
 
 __all__ = [
     "OptionalImport",
+    "is_tensor",
+    "torch_import",
 ]

--- a/pyvisim/lazy_import/torch_backend.py
+++ b/pyvisim/lazy_import/torch_backend.py
@@ -1,0 +1,34 @@
+"""Optional :mod:`torch` backend shared across pyvisim.
+
+:mod:`torch` is an optional dependency installed by the ``nn`` extra
+(``pip install "pyvisim[nn]"``). It is imported lazily through
+:class:`~pyvisim.lazy_import.OptionalImport` so that pyvisim's classical
+(non-neural) features never require it.
+
+The classical image pipeline still *accepts* torch tensors as input when torch
+happens to be installed, but it must not depend on it. :func:`is_tensor`
+captures that contract: it detects tensors when torch is available and returns
+``False`` otherwise, so callers can branch on it without importing torch.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypeGuard
+
+from .lazy_import import OptionalImport
+
+with OptionalImport(package="torch", extra="nn") as torch_import:
+    import torch
+
+
+def is_tensor(obj: Any) -> TypeGuard[torch.Tensor]:
+    """Return whether ``obj`` is a :class:`torch.Tensor`.
+
+    Safe to call when torch is not installed: it short-circuits to ``False``
+    instead of raising, so the classical pipeline can accept torch tensors
+    without depending on torch.
+
+    :param obj: Any object.
+    :return: ``True`` if torch is installed and ``obj`` is a tensor.
+    """
+    return torch_import.is_available and isinstance(obj, torch.Tensor)

--- a/pyvisim/neural_networks/siamese_neural_network.py
+++ b/pyvisim/neural_networks/siamese_neural_network.py
@@ -5,10 +5,6 @@ from .._utils import cosine_similarity
 from ..lazy_import import OptionalImport
 from ..typing import MatLike, NumpyArray
 
-# SiameseNeuralNetwork subclasses torch.nn.Module, so torch (the ``nn`` extra)
-# is required to even define it. torch is imported lazily so importing pyvisim
-# never requires it; importing this module raises an actionable ImportError
-# when torch is missing.
 with OptionalImport(package="torch", extra="nn") as _torch_import:
     import torch
 

--- a/pyvisim/neural_networks/siamese_neural_network.py
+++ b/pyvisim/neural_networks/siamese_neural_network.py
@@ -1,10 +1,18 @@
 from collections.abc import Callable
 
-import torch
-
 from .._base_classes import SimilarityMetric
 from .._utils import cosine_similarity
+from ..lazy_import import OptionalImport
 from ..typing import MatLike, NumpyArray
+
+# SiameseNeuralNetwork subclasses torch.nn.Module, so torch (the ``nn`` extra)
+# is required to even define it. torch is imported lazily so importing pyvisim
+# never requires it; importing this module raises an actionable ImportError
+# when torch is missing.
+with OptionalImport(package="torch", extra="nn") as _torch_import:
+    import torch
+
+_torch_import.check()
 
 
 class SiameseNeuralNetwork(torch.nn.Module, SimilarityMetric):

--- a/pyvisim/retrieval/index/_base_index.py
+++ b/pyvisim/retrieval/index/_base_index.py
@@ -17,19 +17,36 @@ import abc
 from collections.abc import Sequence
 from typing import Any, Literal, cast
 
-import faiss
 import numpy as np
 
+from ...lazy_import import OptionalImport
 from ...typing import Float32NumpyArray, FloatNumpyArray, IntNumpyArray
 
-#: Supported quantizer/metric choices, mapped to their FAISS metric constant.
-_METRICS: dict[str, int] = {
-    "l2": faiss.METRIC_L2,
-    "inner_product": faiss.METRIC_INNER_PRODUCT,
-}
+# faiss ships in the ``search`` extra (``pip install "pyvisim[search]"``) and is
+# imported lazily, so importing pyvisim never requires it. The actionable
+# ImportError is raised when an index is constructed without faiss installed.
+with OptionalImport(package="faiss", extra="search") as _faiss_import:
+    import faiss
+
+#: Supported quantizer/metric choices accepted by the ``quantizer`` argument.
+_SUPPORTED_QUANTIZERS = ("l2", "inner_product")
 
 #: Literal alias for the accepted ``quantizer`` argument.
 Quantizer = Literal["l2", "inner_product"]
+
+
+def _faiss_metric(quantizer: Quantizer) -> int:
+    """
+    Map a quantizer name to its FAISS metric constant.
+
+    :param quantizer: ``"l2"`` or ``"inner_product"``.
+    :return: The matching FAISS metric constant.
+    """
+    metrics: dict[str, int] = {
+        "l2": faiss.METRIC_L2,
+        "inner_product": faiss.METRIC_INNER_PRODUCT,
+    }
+    return metrics[quantizer]
 
 
 class ImageIndex(abc.ABC):
@@ -47,6 +64,8 @@ class ImageIndex(abc.ABC):
     :raises ValueError: If ``quantizer`` is unknown, the gallery is empty, the
         vectors are not a 2-D matrix, or ``paths`` and ``vectors`` differ in
         length.
+    :raises ImportError: If the optional ``faiss`` dependency (the ``search``
+        extra) is not installed.
     """
 
     def __init__(
@@ -56,10 +75,11 @@ class ImageIndex(abc.ABC):
         *,
         quantizer: Quantizer = "l2",
     ) -> None:
-        if quantizer not in _METRICS:
+        _faiss_import.check()
+        if quantizer not in _SUPPORTED_QUANTIZERS:
             raise ValueError(
                 f"Unsupported quantizer {quantizer!r}. Supported quantizers are: "
-                f"{sorted(_METRICS)}."
+                f"{sorted(_SUPPORTED_QUANTIZERS)}."
             )
 
         # Copy into a fresh contiguous float32 matrix so the in-place
@@ -78,7 +98,7 @@ class ImageIndex(abc.ABC):
             )
 
         self._quantizer: Quantizer = quantizer
-        self._metric = _METRICS[quantizer]
+        self._metric = _faiss_metric(quantizer)
         self._paths: list[str] = list(paths)
         self._dim = int(gallery.shape[1])
 

--- a/pyvisim/retrieval/index/_base_index.py
+++ b/pyvisim/retrieval/index/_base_index.py
@@ -22,9 +22,6 @@ import numpy as np
 from ...lazy_import import OptionalImport
 from ...typing import Float32NumpyArray, FloatNumpyArray, IntNumpyArray
 
-# faiss ships in the ``search`` extra (``pip install "pyvisim[search]"``) and is
-# imported lazily, so importing pyvisim never requires it. The actionable
-# ImportError is raised when an index is constructed without faiss installed.
 with OptionalImport(package="faiss", extra="search") as _faiss_import:
     import faiss
 

--- a/pyvisim/retrieval/index/image_index.py
+++ b/pyvisim/retrieval/index/image_index.py
@@ -19,10 +19,15 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
-import faiss
-
+from ...lazy_import import OptionalImport
 from ...typing import Float32NumpyArray, FloatNumpyArray
 from ._base_index import ImageIndex, Quantizer
+
+# faiss ships in the ``search`` extra and is imported lazily (see _base_index).
+# Every index is built through ImageIndex.__init__, which raises the actionable
+# ImportError before any faiss symbol below is touched.
+with OptionalImport(package="faiss", extra="search"):
+    import faiss
 
 
 class ImageIndexIVFFlat(ImageIndex):

--- a/pyvisim/retrieval/index/image_index.py
+++ b/pyvisim/retrieval/index/image_index.py
@@ -23,9 +23,6 @@ from ...lazy_import import OptionalImport
 from ...typing import Float32NumpyArray, FloatNumpyArray
 from ._base_index import ImageIndex, Quantizer
 
-# faiss ships in the ``search`` extra and is imported lazily (see _base_index).
-# Every index is built through ImageIndex.__init__, which raises the actionable
-# ImportError before any faiss symbol below is touched.
 with OptionalImport(package="faiss", extra="search"):
     import faiss
 

--- a/pyvisim/typing/numeric.py
+++ b/pyvisim/typing/numeric.py
@@ -47,13 +47,13 @@ rescaled into the canonical ``[0, 255]`` range.
 """
 
 from collections.abc import Callable, Iterable
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import numpy.typing as npt
-import torch
 
 from .._errors import InvalidImageError
+from ..lazy_import import is_tensor
 
 #: Generic NumPy array of any dtype.
 NumpyArray = npt.NDArray[np.generic]
@@ -74,7 +74,14 @@ SimilarityFunc = Callable[[FloatNumpyArray, FloatNumpyArray], FloatNumpyArray]
 
 #: Anything that can be turned into a numerical NumPy array: a NumPy array, a
 #: PyTorch tensor, or any array-like object (e.g. nested lists of numbers).
-MatLike = torch.Tensor | npt.ArrayLike
+#: ``torch.Tensor`` is part of the union only when torch (the ``nn`` extra) is
+#: installed; without torch the alias collapses to ``npt.ArrayLike`` at runtime.
+if TYPE_CHECKING:
+    import torch
+
+    MatLike = torch.Tensor | npt.ArrayLike
+else:
+    MatLike = npt.ArrayLike
 
 #: A single image or a collection of images. Either one ``MatLike`` object
 #: (optionally carrying a batch axis) or an iterable of ``MatLike`` images.
@@ -93,7 +100,7 @@ def _to_ndarray(data: MatLike) -> NumpyArray:
     :return: The data as a NumPy array.
     :raises InvalidImageError: If the data cannot be turned into a numeric array.
     """
-    if isinstance(data, torch.Tensor):
+    if is_tensor(data):
         return data.detach().cpu().numpy()
     if isinstance(data, np.ndarray):
         array = data


### PR DESCRIPTION
### Related Issues

- fixes None

### Proposed Changes:

Right now a plain `pip install pyvisim` drags in the whole PyTorch stack (torch, torchvision, torchaudio) plus faiss, even if you only ever touch the classical, non-neural features. That's a heavy install for something a lot of users don't need. This PR moves those heavy dependencies behind optional extras and makes every import of them lazy, so importing pyvisim stays lightweight and torch/faiss are only pulled in when you actually use the code that needs them.

The split:

- **`nn` extra** — torch, torchvision, torchaudio and open_clip. Needed for the deep-learning pieces: `DeepConvFeature`, `CLIPEncoder`, and the `datasets` / `neural_networks` modules.
- **`search` extra** — faiss-cpu. Needed for nearest-neighbour retrieval: `ImageIndex`, the in-memory embedding store and `ImageRetriever`.

Both used to live in the core `dependencies`, so this is technically a **breaking change** for anyone relying on the implicit install — they now need `pip install "pyvisim[nn]"` and/or `pip install "pyvisim[search]"`.

How the lazy imports work:

- Every optional import goes through the existing `OptionalImport` context manager. Modules that *define* something on top of an optional dep (e.g. `SiameseNeuralNetwork(torch.nn.Module)`, `OxfordFlowerDataset(Dataset)`) call `.check()` at import time, so you get an actionable `ImportError` naming the right extra the moment you import them. Modules that only *use* the dep at runtime (encoders, indexes) defer the `.check()` into the constructor.
- Added a small shared `torch_backend` helper in `pyvisim.lazy_import` with an `is_tensor()` type guard. The classical image pipeline still *accepts* torch tensors when torch happens to be installed, but must not *depend* on torch — `is_tensor()` short-circuits to `False` when torch is absent, so `_utils`, `encoders.utils` and `typing.numeric` can branch on it without importing torch. `MatLike` now only includes `torch.Tensor` under `TYPE_CHECKING` and collapses to `npt.ArrayLike` at runtime.

A couple of related cleanups came along for the ride:

- `DeepConvFeature`'s `device` default was `"cuda" if torch.cuda.is_available() else "cpu"`, evaluated at import time — which no longer works once torch is lazy. Changed the default to `device=None` and moved the auto-select into a `_resolve_device()` helper that runs at construction.
- Replaced the module-level `_METRICS` dict in `_base_index.py` (which referenced `faiss.METRIC_*` at import time) with a `_faiss_metric()` helper and a plain `_SUPPORTED_QUANTIZERS` tuple, so the metric constants are only touched after the faiss check passes.

### How did you test it?

- `make test-types`, `make test-unit` and `make fmt` all pass locally.
- Updated CI and the Makefile to install the `nn` and `search` extras (`uv sync ... --extra nn --extra search`) so mypy and the test suites still see torch and faiss.
- Worth an extra manual check: install pyvisim *without* the extras and confirm (a) `import pyvisim` succeeds, and (b) constructing a `DeepConvFeature` / `CLIPEncoder` / `ImageIndex` raises the actionable `ImportError` pointing at the right extra.

### Notes for the reviewer

- The main thing to sanity-check is the `.check()` placement: import-time for the modules that subclass an optional type (`datasets`, `neural_networks`), constructor-time for the rest. If any code path can reach a torch/faiss symbol *before* the relevant `.check()`, that's the bug to catch.
- Because this changes the default install surface, the version bump / changelog and the README install instructions should probably be updated in the same release — flagging in case that belongs in this PR.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `refactor!: move torch and faiss to optional 'nn' and 'search' extras`
- [x] I have documented my code.
- [x] When applicable: I have reviewed the AI-generated code sections, according to [contributors guidelines](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#using-ai-to-contribute).
- [x] I have run [pre-commit hooks](https://github.com/MechaCritter/Python-Visual-Similarity/blob/main/CONTRIBUTING.md#set-up-developer-environment) and fixed any issue.
